### PR TITLE
feat(update-docker-dep): add docker dependency update helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ include bin/build/make/git.mak
 
 # Lint all scripts.
 scripts-lint:
-	@shellcheck deps lsp update update-bundler create-ci update-ci update-service update-service-dep update-submodule lib/dirs.sh
+	@shellcheck deps lsp update update-bundler update-docker-dep create-ci update-ci update-service update-service-dep update-submodule lib/dirs.sh

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Top-level scripts:
 - `update-service`: run bulk actions over the `services` set only.
 - `update-bundler`: install a Bundler version and run follow-up make targets.
 - `update-ci`: update CircleCI image tags to latest published Docker Hub tags.
+- `update-docker-dep`: bump a package in the local `alexfalkowski/docker` repo.
 - `update-go-dep`: update outdated Go dependencies using make targets.
 - `update-service-dep`: bump `github.com/alexfalkowski/go-service/v2` in service repos.
 - `update-submodule`: update this repo as a submodule in a target repo.
@@ -43,6 +44,7 @@ Additional requirements by script:
 - `deps`: `go`
 - `lsp`: `ruby`, `bundler`
 - `update-go-dep`: `ruby`
+- `update-docker-dep`: `awk`, `sed`
 - `update-ci`: `curl`, `jq`, `sed`
 - `load`: `vegeta`, `ghz`
 
@@ -311,6 +313,32 @@ Behavior:
 - Otherwise:
   - reads modules from `make outdated-dep`
   - updates each with `make module=<module> update-dep`
+
+### `update-docker-dep`
+
+Update a package in `$HOME/code/docker/<kind>/Dockerfile`.
+
+Syntax:
+
+```bash
+update-docker-dep <kind> <package> <version>
+```
+
+Example:
+
+```bash
+update-docker-dep k8s doctl 1.155.0
+```
+
+Behavior:
+
+- Changes to `$HOME/code/docker`
+- `make name=<kind> new-feature`
+- Updates the first `<package> <version>` occurrence in `<kind>/Dockerfile`
+- Bumps `<kind>/Makefile` `VERSION`:
+  - major image version when the package major version changes
+  - minor image version otherwise
+- Finalizes with `make msg="updated <package> to <version>" ready`
 
 ### `update-service-dep`
 

--- a/update-ci
+++ b/update-ci
@@ -3,8 +3,8 @@
 
 set -eo pipefail
 
-# latest_image from docker hub.
-function latest_image() {
+# Find the newest published Docker Hub tag and drop the patch segment.
+latest_image() {
 	local tag=$(curl -sSL "https://hub.docker.com/v2/repositories/alexfalkowski/$1/tags/?page_size=1000" |
 		jq '.results | .[] | .name' -r |
 		sed 's/latest//' |
@@ -15,8 +15,8 @@ function latest_image() {
 	echo "$tag"
 }
 
-# update_config to the latest images.
-function update_config() {
+# Replace image tags in a CircleCI config with the latest published versions.
+update_config() {
 	readonly file="$1"
 	readonly go_latest=$(latest_image "go")
 	readonly release_latest=$(latest_image "release")

--- a/update-docker-dep
+++ b/update-docker-dep
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2155
+
+set -eo pipefail
+
+readonly dir="$HOME/code/docker"
+readonly kind=$1
+readonly package=$2
+readonly version=$3
+readonly dockerfile="$kind/Dockerfile"
+readonly makefile="$kind/Makefile"
+
+# Extract the major segment from a semantic-ish version.
+major() {
+  local value=${1#v}
+
+  echo "${value%%.*}"
+}
+
+# Bump the image VERSION in the folder Makefile.
+bump_version() {
+  local current=$1
+  local bump=$2
+  local major_version minor_version
+
+  IFS=. read -r major_version minor_version <<< "$current"
+
+  if [ "$bump" = major ]; then
+    echo "$((major_version + 1)).0"
+  else
+    echo "${major_version}.$((minor_version + 1))"
+  fi
+}
+
+# Read the package version currently installed in the Dockerfile.
+current_package_version() {
+  awk -v package="$package" '
+    {
+      for (i = 1; i < NF; i++) {
+        if ($i == package && $(i + 1) ~ /^v?[0-9]/) {
+          print $(i + 1)
+          exit
+        }
+      }
+    }
+  ' "$dockerfile"
+}
+
+# Read the current image VERSION from the folder Makefile.
+current_image_version() {
+  awk -F':=' '$1 == "VERSION" { print $2; exit }' "$makefile"
+}
+
+# Replace the first matching package version in the Dockerfile.
+update_package_version() {
+  sed -i -E "0,/(${package}[[:space:]]+)v?[0-9][^[:space:]\\\\]*/s//\\1${version}/" "$dockerfile"
+}
+
+# Rewrite the folder Makefile with the next image VERSION.
+update_image_version() {
+  local next_version=$1
+
+  awk -v version="$next_version" '
+    BEGIN { updated = 0 }
+    /^VERSION:=/ {
+      print "VERSION:=" version
+      updated = 1
+      next
+    }
+    { print }
+    END { if (!updated) exit 1 }
+  ' "$makefile" > "$makefile.tmp"
+  mv "$makefile.tmp" "$makefile"
+}
+
+(
+  cd "$dir"
+
+  readonly old_package_version=$(current_package_version)
+  readonly old_image_version=$(current_image_version)
+
+  if [ -z "$old_package_version" ]; then
+    echo "could not find package '$package' in $dockerfile" >&2
+    exit 1
+  fi
+
+  if [ -z "$old_image_version" ]; then
+    echo "could not find VERSION in $makefile" >&2
+    exit 1
+  fi
+
+  readonly package_bump=$(
+    if [ "$(major "$old_package_version")" = "$(major "$version")" ]; then
+      echo minor
+    else
+      echo major
+    fi
+  )
+  readonly next_image_version=$(bump_version "$old_image_version" "$package_bump")
+
+  make name="$kind" new-feature
+  update_package_version
+  update_image_version "$next_image_version"
+  make msg="updated $package to $version" ready
+)


### PR DESCRIPTION
## What

- Added `update-docker-dep`, a new helper for bumping package versions in `$HOME/code/docker/<kind>/Dockerfile`.
- The helper bumps the matching image `VERSION` in `<kind>/Makefile`, using a major bump when the package major version changes and a minor bump otherwise.
- The workflow runs in a subshell rooted at `$HOME/code/docker`, creates a feature branch with `make name=<kind> new-feature`, updates files, and finalizes with `make msg="updated <package> to <version>" ready`.
- Added `update-docker-dep` to `make scripts-lint`.
- Documented the new script, requirements, syntax, example, and behavior in `README.md`.
- Cleaned up `update-ci` helper declarations and comments.

## Why

This adds a repeatable wrapper for docker image dependency bumps while matching the repo’s existing maintenance-script workflow.

## Testing

- `make scripts-lint`
- `bash -n update-docker-dep update-ci`
- Mocked `update-docker-dep` runs against temp `$HOME/code/docker` fixtures for minor and major image version bumps.