### PR TITLE
feat(update): separate specialized bulk actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ This runs submodule updates in each configured repo and finalizes with `make don
 ### Upgrade Bundler in Ruby and service repos
 
 ```bash
-./update-ruby bundler 2.5.6 "upgrade bundler"
-./update-ruby done
+./update-ruby all bundler 2.5.6 "upgrade bundler"
+./update-ruby all done
 ```
 
 ### Upgrade Bundler in one target repo
@@ -217,7 +217,7 @@ Examples:
 
 ### `update-service`
 
-Same idea as `update`, but fixed to the `services` list.
+Run service-specific dependency actions across the `services` list.
 
 Syntax:
 
@@ -228,53 +228,44 @@ Syntax:
 Actions:
 
 - `new`: `update-service-dep <kind> <version> <desc>`
-- `latest`: `make latest`
-- `purge`: `make purge`
-- `dep`: `make dep`
 - `done`: `make done`
-- `ci`: `update-ci`
-- `submodule`: `update-submodule <kind> <desc>`
-- `bundler`: `update-bundler "svc" <version> <desc>`
 
 Examples:
 
 ```bash
 ./update-service new svc v2.3.4 "upgrade go-service"
-./update-service dep
-./update-service ci
+./update services dep
+./update services ci
 ```
-
-Important:
-
-- The `bundler` action currently passes `"svc"` as the Bundler version to `update-bundler`. That means it will try `gem install bundler -v svc` and is likely not what you want. Adjust the script before using this action.
 
 ### `update-ruby`
 
-Same idea as `update-service`, but fixed to the `services` and `ruby` lists.
+Run Ruby-specific dependency actions across the `services` and `ruby` lists.
 
 Syntax:
 
 ```bash
-./update-ruby <action> [args...]
+./update-ruby <dirs> <action> [args...]
 ```
+
+`<dirs>`:
+
+- `ruby`
+- `services`
+- `all` (services and Ruby repos)
 
 Actions:
 
 - `new`: `update-ruby-dep <kind> <desc>`
-- `latest`: `make latest`
-- `purge`: `make purge`
-- `dep`: `make dep`
 - `done`: `make done`
-- `ci`: `update-ci`
-- `submodule`: `update-submodule <kind> <desc>`
 - `bundler`: `update-bundler <version> <desc>`
 
 Examples:
 
 ```bash
-./update-ruby new test "update ruby dependencies"
-./update-ruby bundler 2.5.6 "upgrade bundler"
-./update-ruby done
+./update-ruby all new test "update ruby dependencies"
+./update-ruby services bundler 2.5.6 "upgrade bundler"
+./update-ruby all done
 ```
 
 ### `update-bundler`

--- a/update
+++ b/update
@@ -9,19 +9,19 @@ readonly action=$2
 
 case $dirs in
 ruby)
-  directories=("${ruby[@]}")
+  readonly directories=("${ruby[@]}")
   ;;
 
 go)
-  directories=("${go[@]}")
+  readonly directories=("${go[@]}")
   ;;
 
 services)
-  directories=("${services[@]}")
+  readonly directories=("${services[@]}")
   ;;
 
 all)
-  directories=("${all[@]}")
+  readonly directories=("${all[@]}")
   ;;
 
 esac

--- a/update-ruby
+++ b/update-ruby
@@ -4,49 +4,33 @@
 set -eo pipefail
 
 source "$(dirname "$0")"/lib/dirs.sh
-readonly action=$1
-readonly directories=("${services[@]}" "${ruby[@]}")
+readonly dirs=$1
+readonly action=$2
+
+case $dirs in
+ruby)
+  readonly directories=("${ruby[@]}")
+  ;;
+
+services)
+  readonly directories=("${services[@]}")
+  ;;
+
+all)
+  readonly directories=("${services[@]}" "${ruby[@]}")
+  ;;
+esac
 
 case $action in
 new)
   for dir in "${directories[@]}"; do
-    (cd "$dir" && update-ruby-dep "$2" "$3")
-  done
-  ;;
-
-latest)
-  for dir in "${directories[@]}"; do
-    (cd "$dir" && make latest)
-  done
-  ;;
-
-purge)
-  for dir in "${directories[@]}"; do
-    (cd "$dir" && make purge)
-  done
-  ;;
-
-dep)
-  for dir in "${directories[@]}"; do
-    (cd "$dir" && make dep)
+    (cd "$dir" && update-ruby-dep "$3" "$4")
   done
   ;;
 
 bundler)
   for dir in "${directories[@]}"; do
-    (cd "$dir" && update-bundler "$2" "$3")
-  done
-  ;;
-
-submodule)
-  for dir in "${directories[@]}"; do
-    (cd "$dir" && update-submodule "$2" "$3")
-  done
-  ;;
-
-ci)
-  for dir in "${directories[@]}"; do
-    (cd "$dir" && update-ci)
+    (cd "$dir" && update-bundler "$3" "$4")
   done
   ;;
 

--- a/update-service
+++ b/update-service
@@ -13,42 +13,6 @@ new)
   done
   ;;
 
-latest)
-  for dir in "${services[@]}"; do
-    (cd "$dir" && make latest)
-  done
-  ;;
-
-purge)
-  for dir in "${services[@]}"; do
-    (cd "$dir" && make purge)
-  done
-  ;;
-
-dep)
-  for dir in "${services[@]}"; do
-    (cd "$dir" && make dep)
-  done
-  ;;
-
-bundler)
-  for dir in "${services[@]}"; do
-    (cd "$dir" && update-bundler "svc" "$2" "$3")
-  done
-  ;;
-
-submodule)
-  for dir in "${services[@]}"; do
-    (cd "$dir" && update-submodule "$2" "$3")
-  done
-  ;;
-
-ci)
-  for dir in "${services[@]}"; do
-    (cd "$dir" && update-ci)
-  done
-  ;;
-
 done)
   for dir in "${services[@]}"; do
     (cd "$dir" && make done)


### PR DESCRIPTION
## What

- Keep shared maintenance actions in `update` and remove overlapping cases from `update-service` and `update-ruby`.
- Add directory selection to `update-ruby` for `ruby`, `services`, and Ruby-relevant `all` runs.
- Mark selected directory arrays as readonly in `update` and refresh README usage examples.

## Why

- Avoids duplicate command ownership across the bulk wrappers while keeping Ruby and service dependency flows focused.

## Testing

- `make scripts-lint` - passed
- mocked dispatch test for `update-ruby`, `update-service`, and generic `update` actions - passed
