### PR TITLE
feat(update-root): add base image bump helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ include bin/build/make/git.mak
 
 # Lint all scripts.
 scripts-lint:
-	@shellcheck deps lsp update update-bundler update-docker-dep create-ci update-ci update-service update-service-dep update-ruby update-ruby-dep update-submodule lib/dirs.sh
+	@shellcheck deps lsp update update-bundler update-docker-dep update-root create-ci update-ci update-service update-service-dep update-ruby update-ruby-dep update-submodule lib/dirs.sh lib/version.sh

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Top-level scripts:
 - `update-bundler`: install a Bundler version and run follow-up make targets.
 - `update-ci`: update CircleCI image tags to latest published Docker Hub tags.
 - `update-docker-dep`: bump a package in the local `alexfalkowski/docker` repo.
+- `update-root`: bump `alexfalkowski/root` in the local `alexfalkowski/docker` repo.
 - `update-go-dep`: update outdated Go dependencies using make targets.
 - `update-ruby-dep`: update Ruby dependencies using make targets.
 - `update-service-dep`: bump `github.com/alexfalkowski/go-service/v2` in service repos.
@@ -47,6 +48,7 @@ Additional requirements by script:
 - `lsp`: `ruby`, `bundler`
 - `update-go-dep`: `ruby`
 - `update-docker-dep`: `awk`, `sed`
+- `update-root`: `awk`
 - `update-ci`: `curl`, `jq`, `sed`
 - `load`: `vegeta`, `ghz`
 
@@ -391,6 +393,34 @@ Behavior:
   - major image version when the package major version changes
   - minor image version otherwise
 - Finalizes with `make msg="updated <package> to <version>" ready`
+
+### `update-root`
+
+Update `alexfalkowski/root` in every matching `$HOME/code/docker/**/Dockerfile`.
+
+Syntax:
+
+```bash
+update-root <version>
+```
+
+Example:
+
+```bash
+update-root 3.9
+```
+
+Behavior:
+
+- Changes to `$HOME/code/docker`
+- Starts a dependency feature workflow with `make name=deps new-feature`
+- Finds Dockerfiles with a `FROM alexfalkowski/root:<old>` line
+- Updates matching `FROM alexfalkowski/root:<old>` lines to `FROM alexfalkowski/root:<version>`
+- Bumps the `VERSION` in the Makefile beside each matching Dockerfile
+- Uses a major image version bump when the root major version changes
+- Uses a minor image version bump otherwise
+- Exits with an error if no matching Dockerfiles are found
+- Finalizes once with `make msg="updated root to <version>" ready`
 
 ### `update-service-dep`
 

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Extract the major segment from a semantic-ish version.
+version_major() {
+  local value=${1#v}
+
+  echo "${value%%.*}"
+}
+
+# Return major when the major segment changes, minor otherwise.
+version_bump() {
+  local current=$1
+  local next=$2
+
+  if [ "$(version_major "$current")" = "$(version_major "$next")" ]; then
+    echo minor
+  else
+    echo major
+  fi
+}
+
+# Bump an image VERSION.
+version_next() {
+  local current=$1
+  local bump=$2
+  local major_version minor_version
+
+  IFS=. read -r major_version minor_version <<< "$current"
+
+  if [ "$bump" = major ]; then
+    echo "$((major_version + 1)).0"
+  else
+    echo "${major_version}.$((minor_version + 1))"
+  fi
+}
+
+# Read the current image VERSION from a Makefile.
+image_current_version() {
+  local path=$1
+
+  awk -F':=' '$1 == "VERSION" { print $2; exit }' "$path"
+}
+
+# Rewrite a Makefile with the next image VERSION.
+image_update_version() {
+  local path=$1
+  local next_version=$2
+
+  awk -v version="$next_version" '
+    BEGIN { updated = 0 }
+    /^VERSION:=/ {
+      print "VERSION:=" version
+      updated = 1
+      next
+    }
+    { print }
+    END { if (!updated) exit 1 }
+  ' "$path" > "$path.tmp"
+  mv "$path.tmp" "$path"
+}
+
+# Escape a string for use in an extended regular expression.
+version_regex_escape() {
+  printf '%s\n' "$1" | sed -E 's/[][\/.^$*+?{}()|]/\\&/g'
+}

--- a/update-docker-dep
+++ b/update-docker-dep
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2155
+# shellcheck disable=SC2155,SC1091
 
 set -eo pipefail
+
+source "$(dirname "$0")"/lib/version.sh
 
 readonly dir="$HOME/code/docker"
 readonly kind=$1
@@ -9,28 +11,6 @@ readonly package=$2
 readonly version=$3
 readonly dockerfile="$kind/Dockerfile"
 readonly makefile="$kind/Makefile"
-
-# Extract the major segment from a semantic-ish version.
-major() {
-  local value=${1#v}
-
-  echo "${value%%.*}"
-}
-
-# Bump the image VERSION in the folder Makefile.
-bump_version() {
-  local current=$1
-  local bump=$2
-  local major_version minor_version
-
-  IFS=. read -r major_version minor_version <<< "$current"
-
-  if [ "$bump" = major ]; then
-    echo "$((major_version + 1)).0"
-  else
-    echo "${major_version}.$((minor_version + 1))"
-  fi
-}
 
 # Find the matching tool path and version token in the Dockerfile.
 package_version_entry() {
@@ -118,16 +98,6 @@ current_package_version() {
   fi
 }
 
-# Read the current image VERSION from the folder Makefile.
-current_image_version() {
-  awk -F':=' '$1 == "VERSION" { print $2; exit }' "$makefile"
-}
-
-# Escape a string for use in an extended regular expression.
-regex_escape() {
-  printf '%s\n' "$1" | sed -E 's/[][\/.^$*+?{}()|]/\\&/g'
-}
-
 # Replace an ENV variable assignment in the Dockerfile.
 update_env_version() {
   local variable=$1
@@ -154,8 +124,8 @@ update_env_version() {
 
 # Replace a direct tool version token in the Dockerfile.
 update_tool_version() {
-  local path_pattern=$(regex_escape "$(package_path)")
-  local token_pattern=$(regex_escape "$(package_version_token)")
+  local path_pattern=$(version_regex_escape "$(package_path)")
+  local token_pattern=$(version_regex_escape "$(package_version_token)")
 
   sed -i -E "0,/(${path_pattern}[[:space:]]+)${token_pattern}/s//\\1${version}/" "$dockerfile"
 }
@@ -172,28 +142,11 @@ update_package_version() {
   fi
 }
 
-# Rewrite the folder Makefile with the next image VERSION.
-update_image_version() {
-  local next_version=$1
-
-  awk -v version="$next_version" '
-    BEGIN { updated = 0 }
-    /^VERSION:=/ {
-      print "VERSION:=" version
-      updated = 1
-      next
-    }
-    { print }
-    END { if (!updated) exit 1 }
-  ' "$makefile" > "$makefile.tmp"
-  mv "$makefile.tmp" "$makefile"
-}
-
 (
   cd "$dir"
 
   readonly old_package_version=$(current_package_version)
-  readonly old_image_version=$(current_image_version)
+  readonly old_image_version=$(image_current_version "$makefile")
 
   if [ -z "$old_package_version" ]; then
     echo "could not find package '$package' in $dockerfile" >&2
@@ -205,17 +158,11 @@ update_image_version() {
     exit 1
   fi
 
-  readonly package_bump=$(
-    if [ "$(major "$old_package_version")" = "$(major "$version")" ]; then
-      echo minor
-    else
-      echo major
-    fi
-  )
-  readonly next_image_version=$(bump_version "$old_image_version" "$package_bump")
+  readonly package_bump=$(version_bump "$old_package_version" "$version")
+  readonly next_image_version=$(version_next "$old_image_version" "$package_bump")
 
   make name="$kind" new-feature
   update_package_version
-  update_image_version "$next_image_version"
+  image_update_version "$makefile" "$next_image_version"
   make msg="updated $package to $version" ready
 )

--- a/update-root
+++ b/update-root
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+
+# Update alexfalkowski/root across the local docker image repository.
+
+set -eo pipefail
+
+source "$(dirname "$0")"/lib/version.sh
+
+readonly dir="$HOME/code/docker"
+readonly image="alexfalkowski/root"
+readonly version=$1
+
+if [ -z "$version" ]; then
+  echo "usage: update-root <version>" >&2
+  exit 1
+fi
+
+# Read the current root image version from a Dockerfile.
+current_root_version() {
+  local dockerfile=$1
+
+  awk -v image="$image" '
+    $1 == "FROM" {
+      split($2, parts, ":")
+      if (parts[1] == image) {
+        print parts[2]
+        exit
+      }
+    }
+  ' "$dockerfile"
+}
+
+# Replace root image versions in a Dockerfile.
+update_root_version() {
+  local dockerfile=$1
+
+  awk -v image="$image" -v version="$version" '
+    $1 == "FROM" {
+      split($2, parts, ":")
+      if (parts[1] == image) {
+        $2 = image ":" version
+        updated = 1
+      }
+    }
+    { print }
+    END { if (!updated) exit 1 }
+  ' "$dockerfile" > "$dockerfile.tmp"
+  mv "$dockerfile.tmp" "$dockerfile"
+}
+
+(
+  cd "$dir"
+
+  found=false
+
+  make name=deps new-feature
+
+  while IFS= read -r dockerfile; do
+    dockerfile=${dockerfile#./}
+    makefile="${dockerfile%/Dockerfile}/Makefile"
+    old_root_version=$(current_root_version "$dockerfile")
+
+    if [ -z "$old_root_version" ]; then
+      continue
+    fi
+
+    found=true
+    old_image_version=$(image_current_version "$makefile")
+
+    if [ -z "$old_image_version" ]; then
+      echo "could not find VERSION in $makefile" >&2
+      exit 1
+    fi
+
+    root_bump=$(version_bump "$old_root_version" "$version")
+    next_image_version=$(version_next "$old_image_version" "$root_bump")
+
+    update_root_version "$dockerfile"
+    image_update_version "$makefile" "$next_image_version"
+  done < <(find . -name Dockerfile -print | sort)
+
+  if [ "$found" = false ]; then
+    echo "could not find image '$image' in $dir" >&2
+    exit 1
+  fi
+
+  make msg="updated root to $version" ready
+)


### PR DESCRIPTION
## What

- Added shared version helpers for image major/minor bump calculations, Makefile VERSION reads/writes, and regex escaping.
- Added update-root to bump alexfalkowski/root references across the local docker image repo and bump each matching image VERSION.
- Refactored update-docker-dep to reuse the shared version helpers.
- Documented update-root and included it in script lint coverage.

## Why

- Root image bumps need the same Dockerfile and Makefile version workflow as package dependency bumps without duplicating the version handling logic.

## Testing

- `make scripts-lint` - passed
- temp dry run for `update-root 3.9` - passed
- temp dry run for `update-docker-dep go shellcheck v0.12.0` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
