### PR TITLE
feat(update-docker-dep): reject unchanged package versions

### DIFF
--- a/update-docker-dep
+++ b/update-docker-dep
@@ -158,6 +158,11 @@ update_package_version() {
     exit 1
   fi
 
+  if [ "$old_package_version" = "$version" ]; then
+    echo "package '$package' is already at version $version in $dockerfile" >&2
+    exit 1
+  fi
+
   readonly package_bump=$(version_bump "$old_package_version" "$version")
   readonly next_image_version=$(version_next "$old_image_version" "$package_bump")
 


### PR DESCRIPTION
## What

- Added a guard that fails when `update-docker-dep` is asked to set a package to its current Dockerfile version.
- Kept the guard before branch creation, Dockerfile edits, and image version updates.

## Why

- Avoid creating no-op dependency update branches and image version bumps when the package version is already current.

## Testing

- `make scripts-lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
