### PR TITLE
feat(security): fail fast in maintenance helpers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,8 @@ workflows:
           filters:
             branches:
               only: master
+      # CircleCI ignores filtered-out required jobs, so this waits for
+      # lint+version on master and lint+sync on non-master branches.
       - wait-all:
           requires:
             - lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bundle/
 vendor
 *.bin
+ISSUES.md

--- a/load
+++ b/load
@@ -11,6 +11,11 @@ source "$(dirname "$0")"/lib/dirs.sh
 readonly kind=$1
 readonly service=$2
 
+usage() {
+  echo "usage: load <http|grpc> <standort|bezeichner>" >&2
+  exit 1
+}
+
 case $kind in
   http)
     case $service in
@@ -19,6 +24,9 @@ case $kind in
       ;;
     bezeichner)
       echo "POST http://localhost:11001/bezeichner.v1.Service/GenerateIdentifiers" | vegeta attack -duration=30s -body "data/bezeichner.json" -header "Content-Type: application/json" | tee "data/bezeichner.bin" | vegeta report
+      ;;
+    *)
+      usage
       ;;
     esac
     ;;
@@ -30,6 +38,12 @@ case $kind in
     bezeichner)
       ghz --insecure -n 2000 -c 20 --call bezeichner.v1.Service/GenerateIdentifiers -d '{ "application": "ulid", "count": 10 }' localhost:12001
       ;;
+    *)
+      usage
+      ;;
     esac
+    ;;
+  *)
+    usage
     ;;
 esac

--- a/update-ci
+++ b/update-ci
@@ -1,28 +1,40 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2086,SC2155
 
 set -eo pipefail
 
 # Find the newest published Docker Hub tag and drop the patch segment.
 latest_image() {
-	local tag=$(curl -sSL "https://hub.docker.com/v2/repositories/alexfalkowski/$1/tags/?page_size=1000" |
+	local image=$1
+	local tag
+
+	if ! tag=$(curl -fsSL "https://hub.docker.com/v2/repositories/alexfalkowski/$image/tags/?page_size=1000" |
 		jq '.results | .[] | .name' -r |
-		sed 's/latest//' |
+		sed '/^latest$/d' |
 		sort --version-sort |
 		tail -n 1 |
-		sed 's/\.[^.]*$//')
+		sed 's/\.[^.]*$//'); then
+		echo "could not resolve latest image for $image" >&2
+		return 1
+	fi
+
+	if [ -z "$tag" ]; then
+		echo "empty latest image tag for $image" >&2
+		return 1
+	fi
 
 	echo "$tag"
 }
 
 # Replace image tags in a CircleCI config with the latest published versions.
 update_config() {
-	readonly file="$1"
-	readonly go_latest=$(latest_image "go")
-	readonly release_latest=$(latest_image "release")
-	readonly ruby_latest=$(latest_image "ruby")
-	readonly k8s_latest=$(latest_image "k8s")
-	readonly docker_latest=$(latest_image "docker")
+	local file=$1
+	local go_latest release_latest ruby_latest k8s_latest docker_latest
+
+	go_latest=$(latest_image "go")
+	release_latest=$(latest_image "release")
+	ruby_latest=$(latest_image "ruby")
+	k8s_latest=$(latest_image "k8s")
+	docker_latest=$(latest_image "docker")
 
 	# Replace all instances.
 	sed -i \
@@ -31,7 +43,7 @@ update_config() {
 		-e "s/alexfalkowski\/ruby\:.*/alexfalkowski\/ruby\:${ruby_latest}/g" \
 		-e "s/alexfalkowski\/k8s\:.*/alexfalkowski\/k8s\:${k8s_latest}/g" \
 		-e "s/alexfalkowski\/docker\:.*/alexfalkowski\/docker\:${docker_latest}/g" \
-		$file
+		"$file"
 }
 
 make name=ci new-build

--- a/update-docker-dep
+++ b/update-docker-dep
@@ -5,10 +5,20 @@ set -eo pipefail
 
 source "$(dirname "$0")"/lib/version.sh
 
+usage() {
+  echo "usage: update-docker-dep <kind> <package> <version>" >&2
+  exit 1
+}
+
 readonly dir="$HOME/code/docker"
 readonly kind=$1
 readonly package=$2
 readonly version=$3
+
+if [ -z "$kind" ] || [ -z "$package" ] || [ -z "$version" ]; then
+  usage
+fi
+
 readonly dockerfile="$kind/Dockerfile"
 readonly makefile="$kind/Makefile"
 
@@ -62,8 +72,10 @@ version_variable() {
   local value=${1#\"}
   value=${value%\"}
 
-  if [[ $value =~ ^\$[[:alpha:]_][[:alnum:]_]*$ ]]; then
-    echo "${value#\$}"
+  if [[ $value =~ ^\$([[:alpha:]_][[:alnum:]_]*)$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  elif [[ $value =~ ^\$\{([[:alpha:]_][[:alnum:]_]*)\}$ ]]; then
+    echo "${BASH_REMATCH[1]}"
   fi
 }
 
@@ -73,14 +85,22 @@ env_version() {
 
   awk -v variable="$variable" '
     $1 == "ENV" {
-      split($2, parts, "=")
-      if (parts[1] == variable) {
-        print parts[2]
-        exit
-      }
       if ($2 == variable) {
         print $3
         exit
+      }
+      for (i = 2; i <= NF; i++) {
+        if (index($i, "=") == 0) {
+          continue
+        }
+        key = $i
+        value = $i
+        sub(/=.*/, "", key)
+        sub(/^[^=]*=/, "", value)
+        if (key == variable) {
+          print value
+          exit
+        }
       }
     }
   ' "$dockerfile"
@@ -104,16 +124,24 @@ update_env_version() {
 
   awk -v variable="$variable" -v version="$version" '
     $1 == "ENV" && !updated {
-      split($2, parts, "=")
-      if (parts[1] == variable) {
-        print "ENV " variable "=" version
+      if ($2 == variable) {
+        $3 = version
         updated = 1
+        print
         next
       }
-      if ($2 == variable) {
-        print "ENV " variable " " version
-        updated = 1
-        next
+      for (i = 2; i <= NF; i++) {
+        if (index($i, "=") == 0) {
+          continue
+        }
+        key = $i
+        sub(/=.*/, "", key)
+        if (key == variable) {
+          $i = variable "=" version
+          updated = 1
+          print
+          next
+        }
       }
     }
     { print }

--- a/update-go-dep
+++ b/update-go-dep
@@ -1,16 +1,29 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'open3'
+
+def make_output(*args)
+  output, status = Open3.capture2('make', *args)
+  abort("make #{args.join(' ')} failed") unless status.success?
+
+  output.split("\n")
+end
+
+def make(*args)
+  return if system('make', *args)
+
+  abort("make #{args.join(' ')} failed")
+end
+
 if File.exist?('test/Gemfile')
-  deps = `make go-outdated-dep`.split("\n")
-  deps.each do |d|
-    m, = d.split
-    `make module=#{m} go-update-dep`
+  make_output('go-outdated-dep').each do |dep|
+    mod, = dep.split
+    make("module=#{mod}", 'go-update-dep')
   end
 else
-  deps = `make outdated-dep`.split("\n")
-  deps.each do |d|
-    m, = d.split
-    `make module=#{m} update-dep`
+  make_output('outdated-dep').each do |dep|
+    mod, = dep.split
+    make("module=#{mod}", 'update-dep')
   end
 end

--- a/update-root
+++ b/update-root
@@ -53,8 +53,7 @@ update_root_version() {
   cd "$dir"
 
   found=false
-
-  make name=deps new-feature
+  updated=false
 
   while IFS= read -r dockerfile; do
     dockerfile=${dockerfile#./}
@@ -66,6 +65,11 @@ update_root_version() {
     fi
 
     found=true
+
+    if [ "$old_root_version" = "$version" ]; then
+      continue
+    fi
+
     old_image_version=$(image_current_version "$makefile")
 
     if [ -z "$old_image_version" ]; then
@@ -76,12 +80,22 @@ update_root_version() {
     root_bump=$(version_bump "$old_root_version" "$version")
     next_image_version=$(version_next "$old_image_version" "$root_bump")
 
+    if [ "$updated" = false ]; then
+      make name=deps new-feature
+    fi
+
     update_root_version "$dockerfile"
     image_update_version "$makefile" "$next_image_version"
+    updated=true
   done < <(find . -name Dockerfile -print | sort)
 
   if [ "$found" = false ]; then
     echo "could not find image '$image' in $dir" >&2
+    exit 1
+  fi
+
+  if [ "$updated" = false ]; then
+    echo "image '$image' is already at version $version in $dir" >&2
     exit 1
   fi
 


### PR DESCRIPTION
## What

- Hardened maintenance scripts so failed lookups, failed make updates, missing arguments, no-op root image bumps, and unsupported load-test arguments fail visibly instead of silently succeeding or mutating files incorrectly.
- Improved Dockerfile ENV handling for dependency bumps, including braced variable references and multi-assignment ENV lines without dropping sibling assignments.
- Documented the CircleCI wait-all dependency behavior in the workflow config and ignored temporary issue ledgers.

## Why

- These wrappers are reused across repositories, so silent success on failed maintenance paths can create broken CI config, false dependency releases, or incomplete updates that look successful.
- Keeping the CircleCI behavior documented in the YAML prevents the valid filtered-dependency pattern from being rediscovered as a false issue.

## Testing

- `make scripts-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `git diff --check` - passed
- `ruby -c update-go-dep` - passed
- `ruby -e 'require "yaml"; YAML.load_file(".circleci/config.yml")'` - passed
- Targeted temp-fixture checks covered update-ci lookup failure without config rewrite, update-go-dep make failure propagation, update-docker-dep ENV updates, update-root no-op skipping, and load invalid-argument failures.

AI-assisted-by: [Codex](https://openai.com/codex/)
