### PR TITLE
feat(update-service): generate release descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,11 @@ runs each repo's `make done`.
 ### 🧩 Bump `go-service` dependency in all services
 
 ```bash
-./update-service new svc v2.3.4 "upgrade go-service"
+./update-service new svc v2.3.4
 ./update-service done
 ```
 
-Replace `v2.3.4` and description as needed.
+Replace `v2.3.4` as needed.
 
 ### 📌 Bump `bin` submodule across all configured repos
 
@@ -425,13 +425,13 @@ Syntax:
 
 Actions:
 
-- `new`: `update-service-dep <kind> <version> <desc>`
+- `new`: `update-service-dep <kind> <version>`
 - `done`: `make done`
 
 Examples:
 
 ```bash
-./update-service new svc v2.3.4 "upgrade go-service"
+./update-service new svc v2.3.4
 ./update-service done
 ```
 
@@ -631,13 +631,13 @@ Run inside a service repository.
 Syntax:
 
 ```bash
-update-service-dep <kind> <version> <desc>
+update-service-dep <kind> <version>
 ```
 
 Example:
 
 ```bash
-update-service-dep svc v2.3.4 "upgrade go-service"
+update-service-dep svc v2.3.4
 ```
 
 Behavior:
@@ -646,7 +646,7 @@ Behavior:
 - Runs `make module=github.com/alexfalkowski/go-service/v2@<version> go-get`.
 - Runs `make submodule go-dep ruby-update-all-dep`.
 - Finalizes with
-  `make msg="upgraded github.com/alexfalkowski/go-service/v2 to <version>" desc="<desc>" ready`.
+  `make msg="upgraded github.com/alexfalkowski/go-service/v2 to <version>" desc="https://github.com/alexfalkowski/go-service/releases/tag/<version>" ready`.
 
 ### 📌 `update-submodule`
 

--- a/update-service
+++ b/update-service
@@ -9,7 +9,7 @@ readonly action=$1
 case $action in
 new)
   for dir in "${services[@]}"; do
-    (cd "$dir" && update-service-dep "$2" "$3" "$4")
+    (cd "$dir" && update-service-dep "$2" "$3")
   done
   ;;
 

--- a/update-service-dep
+++ b/update-service-dep
@@ -4,7 +4,7 @@ set -eo pipefail
 
 readonly kind=$1
 readonly version=$2
-readonly desc=$3
+readonly desc="https://github.com/alexfalkowski/go-service/releases/tag/${version}"
 
 make name=deps new-"${kind}"
 make module=github.com/alexfalkowski/go-service/v2@"$version" go-get


### PR DESCRIPTION
## What

- Generated the go-service release URL inside `update-service-dep` from the requested version.
- Removed the extra description argument from `update-service new` and refreshed README usage for both commands.

## Why

- Keeps service dependency bump descriptions consistent with the actual go-service release tag.
- Simplifies the bulk service bump command so callers only provide the kind and version.

## Testing

- `make scripts-lint` - passed
- `git diff --check` - passed
- Did not run the live downstream service update flow because it would modify configured service repositories.

AI-assisted-by: [Codex](https://openai.com/codex/)
