### PR TITLE
docs(readme): clarify load test working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ CircleCI triggers.
 
 ### 📈 Local load test cycle
 
+Run the load test cycle from this repository root. The service commands read
+the config files under [`config/`](config/) and `load` reads and writes the
+payload/report files under [`data/`](data/) relative to the current directory.
+
 Start the services first:
 
 ```bash
@@ -284,6 +288,10 @@ Current tool list is defined directly in [`deps`](deps).
 ### 📈 `load`
 
 Run local HTTP or gRPC load tests for `standort` and `bezeichner`.
+
+Run this command from the repository root. It reads request payloads from
+`data/*.json` and writes HTTP report binaries to `data/*.bin` relative to the
+current directory.
 
 Syntax:
 


### PR DESCRIPTION
## What

- Clarifies that the local load test cycle must run from this repository root.
- Documents that service config files and load payload/report files are resolved relative to the current directory.

## Why

- Prevents confusing load test failures or misplaced report output when `load` is invoked from another directory or only through `PATH`.

## Testing

- `git diff --check` - passed
- Reviewed the README change against the actual `load` script paths and scoped validation to whitespace/diff integrity because no executable behavior changed.
