### PR TITLE
build(git): align generated file ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
 .bundle/
-vendor
-*.bin
+.crush/
+.ruby-lsp/
+.source-key
 ISSUES.md
+TESTS.md
+DOCS.md
+FEATURES.md
+PROJECTS.md
+RELIABILITY.md
+vendor/
+*.bin


### PR DESCRIPTION
## What

- Update repository ignore rules for local agent and editor state, generated source keys, issue ledger files, dependency mirrors, report outputs, and local build artifacts where applicable.
- Preserve tracked report placeholders while ignoring generated report contents where the repository has a reports directory.

## Why

- Keeps generated and machine-local files out of source control without depending on global Git ignores.
- Makes each repository's ignore policy match the shared build workflow cleanup before future generated artifact cleanup.

## Testing

- `git ls-files -ci --exclude-standard` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
