### PR TITLE
feat(ai): add configurable coding-agent launcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ include bin/build/make/codex.mak
 
 # Lint all shell scripts.
 scripts-lint:
-	@shellcheck clean create-ci deps load lsp rotate-ci rotate-oauth-ci update update-bundler update-ci update-docker-dep update-root update-ruby update-ruby-dep update-service update-service-dep update-submodule lib/dirs.sh lib/slugs.sh lib/version.sh
+	@shellcheck ai clean create-ci deps load lsp rotate-ci rotate-oauth-ci update update-bundler update-ci update-docker-dep update-root update-ruby update-ruby-dep update-service update-service-dep update-submodule lib/dirs.sh lib/slugs.sh lib/version.sh

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Utility scripts for running repeatable maintenance across multiple repositories
 
 Top-level scripts:
 
+- `ai`: start Codex or Claude with a kind-specific model, reasoning level, and prompt preamble.
 - `clean`: remove dependency vendor directories and rerun `make dep`.
 - `create-ci`: create/configure a CircleCI project and trigger its first pipeline.
 - `deps`: install/update shared Go developer tools.
@@ -53,6 +54,7 @@ Base requirements:
 
 Additional requirements by script:
 
+- `ai`: Codex CLI (`codex`) and/or Claude Code (`claude`), depending on the selected provider
 - `create-ci`: `curl`, `CIRCLECI_API_TOKEN`, `CODECOV_TOKEN`
 - `deps`: `go`
 - `load`: `vegeta`, `ghz`
@@ -298,6 +300,45 @@ Behavior:
 - Removes `test/vendor` when it exists.
 - Removes `vendor` when it exists.
 - Runs `make dep`.
+
+### 🤖 `ai`
+
+Start an interactive Codex or Claude session for a configured kind.
+
+Syntax:
+
+```bash
+ai <codex|claude> <kind> [prompt...]
+```
+
+Examples:
+
+```bash
+ai codex code "add a cache for this request"
+ai claude test-gaps "focus on the command-line interface"
+```
+
+Kinds:
+
+- `code`
+- `test-gaps`
+- `reliability-gaps`
+- `project-gaps`
+- `feature-gaps`
+- `doc-gaps`
+
+The model, reasoning level, and prompt preamble are configured in
+[`config/ai.conf`](config/ai.conf). Each non-comment line uses this format:
+
+```text
+kind|codex_model|codex_reasoning|claude_model|claude_effort|preamble
+```
+
+`code` has no injected preamble. Each gap kind starts with `$<kind>` for Codex
+or `/<kind>` for Claude, followed by its configured preamble and then the
+optional prompt. Edit the final field to fine-tune each skill; use `-` when a
+kind should have no preamble. The selected skill must already be available in
+the repository where you run `ai`.
 
 ### 🚀 `create-ci`
 

--- a/ai
+++ b/ai
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# Starts an interactive Codex or Claude session using the selected kind's configuration.
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly script_dir
+config_file="$script_dir/config/ai.conf"
+readonly config_file
+
+usage() {
+  echo "usage: ai <codex|claude> <kind> [prompt...]" >&2
+  exit 1
+}
+
+if [ $# -lt 2 ]; then
+  usage
+fi
+
+readonly provider=$1
+readonly kind=$2
+shift 2
+
+case $provider in
+codex | claude)
+  ;;
+*)
+  echo "unknown provider: $provider" >&2
+  exit 1
+  ;;
+esac
+
+if [ ! -r "$config_file" ]; then
+  echo "unable to read configuration: $config_file" >&2
+  exit 1
+fi
+
+model=
+reasoning=
+preamble=
+skill_prefix=
+
+while IFS='|' read -r configured_kind codex_model codex_reasoning claude_model claude_effort configured_preamble; do
+  case $configured_kind in
+  '' | \#*)
+    continue
+    ;;
+  esac
+
+  if [ "$configured_kind" != "$kind" ]; then
+    continue
+  fi
+
+  case $provider in
+  codex)
+    model=$codex_model
+    reasoning=$codex_reasoning
+    skill_prefix='$'
+    ;;
+  claude)
+    model=$claude_model
+    reasoning=$claude_effort
+    skill_prefix='/'
+    ;;
+  *)
+    usage
+    ;;
+  esac
+
+  preamble=$configured_preamble
+  break
+done < "$config_file"
+
+if [ -z "$model" ] || [ -z "$reasoning" ]; then
+  echo "unknown kind: $kind" >&2
+  exit 1
+fi
+
+if [ "$preamble" = '-' ]; then
+  preamble=
+fi
+
+prompt=$*
+if [ -n "$preamble" ]; then
+  prompt="${skill_prefix}${kind} ${preamble}"
+  if [ $# -gt 0 ]; then
+    prompt="$prompt"$'\n\n'"$*"
+  fi
+fi
+
+case $provider in
+codex)
+  command=(codex --model "$model" -c "model_reasoning_effort=\"$reasoning\"")
+  ;;
+claude)
+  command=(claude --model "$model" --effort "$reasoning")
+  ;;
+esac
+
+if [ -n "$prompt" ]; then
+  command+=("$prompt")
+fi
+
+exec "${command[@]}"

--- a/config/ai.conf
+++ b/config/ai.conf
@@ -1,0 +1,8 @@
+# kind|codex_model|codex_reasoning|claude_model|claude_effort|preamble
+# Use - as the preamble when the kind should not invoke a provider skill.
+code|gpt-5.6-luna|xhigh|sonnet|high|-
+test-gaps|gpt-5.6-sol|max|opus|xhigh|Inspect this repository with agents and a goal.
+reliability-gaps|gpt-5.6-sol|max|opus|xhigh|Inspect this repository with agents and a goal.
+project-gaps|gpt-5.6-sol|max|opus|xhigh|Inspect this repository with agents and a goal.
+feature-gaps|gpt-5.6-sol|max|opus|xhigh|Inspect this repository with agents and a goal.
+doc-gaps|gpt-5.6-sol|max|opus|xhigh|Inspect this repository with agents and a goal.


### PR DESCRIPTION
## What

- Add an interactive coding-agent launcher that routes code and repository-gap work to configured Codex or Claude models.
- Provide editable per-kind model, reasoning, and prompt-preamble configuration with provider-specific skill invocation.
- Document the command and configuration format, include it in ShellCheck coverage, and return clear errors for invalid providers, kinds, or unreadable configuration.

## Why

- Give maintainers one repeatable command for starting the appropriate coding agent with the intended reasoning level and repository workflow context.

## Testing

- `make scripts-lint` - passed
- `./ai codex code --help` and `./ai claude code --help` - passed; validate provider CLI invocation without starting a session.
- `./ai invalid-provider code` and `./ai codex invalid-kind` - passed; validate local argument errors.
- `codex debug models | jq ...` - passed; confirms `gpt-5.6-sol` supports `max` reasoning.
- `make sec` - not run; the Trivy database may require a network update, and CircleCI runs this scan.
- No existing command-wrapper test harness; real provider sessions were intentionally not started.

AI-assisted-by: [Codex](https://openai.com/codex/)
