### PR TITLE
feat(ai): resolve unlisted kinds from bin skills automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Base requirements:
 
 Additional requirements by script:
 
-- `ai`: Codex CLI (`codex`) and/or Claude Code (`claude`), depending on the selected provider
+- `ai`: `yq`, plus Codex CLI (`codex`) and/or Claude Code (`claude`), depending
+  on the selected provider
 - `create-ci`: `curl`, `CIRCLECI_API_TOKEN`, `CODECOV_TOKEN`
 - `deps`: `go`
 - `load`: `vegeta`, `ghz`
@@ -318,27 +319,32 @@ ai codex code "add a cache for this request"
 ai claude test-gaps "focus on the command-line interface"
 ```
 
-Kinds:
-
-- `code`
-- `test-gaps`
-- `reliability-gaps`
-- `project-gaps`
-- `feature-gaps`
-- `doc-gaps`
-
 The model, reasoning level, and prompt preamble are configured in
-[`config/ai.conf`](config/ai.conf). Each non-comment line uses this format:
+[`config/ai.yml`](config/ai.yml), read with `yq`. Each entry under `kinds`
+looks like this:
 
-```text
-kind|codex_model|codex_reasoning|claude_model|claude_effort|preamble
+```yaml
+kinds:
+  test-gaps:
+    codex:
+      model: gpt-5.6-sol
+      reasoning: max
+    claude:
+      model: opus
+      effort: xhigh
+    preamble: Inspect this repository with agents and a goal.
 ```
 
-`code` has no injected preamble. Each gap kind starts with `$<kind>` for Codex
-or `/<kind>` for Claude, followed by its configured preamble and then the
-optional prompt. Edit the final field to fine-tune each skill; use `-` when a
-kind should have no preamble. The selected skill must already be available in
-the repository where you run `ai`.
+`code` has no injected preamble (`preamble: "-"`) and is not a `bin` skill, so
+it always needs its own entry. Any other kind that has no entry of its own
+falls back to `kinds.default` as long as a matching `bin/skills/<kind>`
+directory exists, so new shared skills work with `ai` without editing this
+file. Add a kind-specific entry only to override the default model,
+reasoning, or preamble for that skill.
+
+Each configured kind starts with `$<kind>` for Codex or `/<kind>` for Claude,
+followed by its preamble and then the optional prompt. The selected skill must
+already be available in the repository where you run `ai`.
 
 ### 🚀 `create-ci`
 

--- a/ai
+++ b/ai
@@ -5,8 +5,10 @@ set -eo pipefail
 # Starts an interactive Codex or Claude session using the selected kind's configuration.
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 readonly script_dir
-config_file="$script_dir/config/ai.conf"
+config_file="$script_dir/config/ai.yml"
 readonly config_file
+skills_dir="$script_dir/bin/skills"
+readonly skills_dir
 
 usage() {
   echo "usage: ai <codex|claude> <kind> [prompt...]" >&2
@@ -35,43 +37,44 @@ if [ ! -r "$config_file" ]; then
   exit 1
 fi
 
-model=
-reasoning=
-preamble=
-skill_prefix=
+if ! command -v yq >/dev/null 2>&1; then
+  echo "yq is required to read $config_file" >&2
+  exit 1
+fi
 
-while IFS='|' read -r configured_kind codex_model codex_reasoning claude_model claude_effort configured_preamble; do
-  case $configured_kind in
-  '' | \#*)
-    continue
-    ;;
-  esac
+export KIND=$kind
 
-  if [ "$configured_kind" != "$kind" ]; then
-    continue
-  fi
+if [ "$(yq eval '.kinds | has(env(KIND))' "$config_file")" = true ]; then
+  base='.kinds[env(KIND)]'
+elif [ -d "$skills_dir/$kind" ]; then
+  base='.kinds.default'
+else
+  echo "unknown kind: $kind" >&2
+  exit 1
+fi
 
-  case $provider in
-  codex)
-    model=$codex_model
-    reasoning=$codex_reasoning
-    skill_prefix='$'
-    ;;
-  claude)
-    model=$claude_model
-    reasoning=$claude_effort
-    skill_prefix='/'
-    ;;
-  *)
-    usage
-    ;;
-  esac
+codex_model=$(yq eval "${base}.codex.model" "$config_file")
+codex_reasoning=$(yq eval "${base}.codex.reasoning" "$config_file")
+claude_model=$(yq eval "${base}.claude.model" "$config_file")
+claude_effort=$(yq eval "${base}.claude.effort" "$config_file")
+preamble=$(yq eval "${base}.preamble" "$config_file")
 
-  preamble=$configured_preamble
-  break
-done < "$config_file"
+unset KIND
 
-if [ -z "$model" ] || [ -z "$reasoning" ]; then
+case $provider in
+codex)
+  model=$codex_model
+  reasoning=$codex_reasoning
+  skill_prefix='$'
+  ;;
+claude)
+  model=$claude_model
+  reasoning=$claude_effort
+  skill_prefix='/'
+  ;;
+esac
+
+if [ -z "$model" ] || [ "$model" = null ] || [ -z "$reasoning" ] || [ "$reasoning" = null ]; then
   echo "unknown kind: $kind" >&2
   exit 1
 fi

--- a/config/ai.conf
+++ b/config/ai.conf
@@ -1,8 +1,0 @@
-# kind|codex_model|codex_reasoning|claude_model|claude_effort|preamble
-# Use - as the preamble when the kind should not invoke a provider skill.
-code|gpt-5.6-luna|xhigh|sonnet|high|-
-test-gaps|gpt-5.6-sol|max|opus|xhigh|Inspect this repository with agents and a goal.
-reliability-gaps|gpt-5.6-sol|max|opus|xhigh|Inspect this repository with agents and a goal.
-project-gaps|gpt-5.6-sol|max|opus|xhigh|Inspect this repository with agents and a goal.
-feature-gaps|gpt-5.6-sol|max|opus|xhigh|Inspect this repository with agents and a goal.
-doc-gaps|gpt-5.6-sol|max|opus|xhigh|Inspect this repository with agents and a goal.

--- a/config/ai.yml
+++ b/config/ai.yml
@@ -1,0 +1,25 @@
+# Read by `ai`. Each kind configures the Codex and Claude model/reasoning
+# level to use, plus a prompt preamble.
+#
+# Use "-" as a kind's preamble when it should not invoke a provider skill.
+#
+# `default` configures any kind that has no entry of its own here but matches
+# a skill directory under bin/skills/<kind>, so new shared skills work with
+# `ai` without editing this file.
+kinds:
+  code:
+    codex:
+      model: gpt-5.6-luna
+      reasoning: xhigh
+    claude:
+      model: sonnet
+      effort: high
+    preamble: "-"
+  default:
+    codex:
+      model: gpt-5.6-sol
+      reasoning: max
+    claude:
+      model: opus
+      effort: xhigh
+    preamble: Inspect this repository with agents and a goal.


### PR DESCRIPTION
## What

- `ai` now reads its per-kind Codex/Claude model, reasoning level, and prompt preamble from `config/ai.yml` (YAML, parsed with `yq`) instead of the old pipe-delimited `config/ai.conf`.
- A kind that has no explicit entry under `kinds` in `config/ai.yml` now resolves against `kinds.default` as long as a matching `bin/skills/<kind>` directory exists. `code` keeps its own entry since it has no injected preamble and is not a `bin` skill.
- `README.md` documents the new YAML shape, the `default` fallback rule, and adds `yq` to the prerequisites for `ai`.

## Why

- `config/ai.conf` used to hardcode one line per gap-style kind (`test-gaps`, `reliability-gaps`, `project-gaps`, `feature-gaps`, `doc-gaps`), duplicating skill names that are actually owned and defined by the `bin` submodule. Adding, renaming, or removing a shared skill in `bin/skills` required a matching manual edit here, and any skill that was never explicitly added (for example `api-standards`) silently couldn't be used through `ai`.
- Falling back to `bin/skills/<kind>` removes that duplication: any current or future shared skill works with `ai` immediately, and `config/ai.yml` only needs an entry when a kind needs settings that differ from the default.

## Testing

- `make scripts-lint` - passed
- Manual verification with faked `claude`/`codex` executables on `PATH`, covering: the `code` kind, an explicitly-listed gap kind (`test-gaps`), a `bin` skill that was never listed in the old config (`api-standards`), and an unknown kind (still errors with `unknown kind: <kind>`).
- Code review pass caught `KIND` being exported into the environment of the launched `claude`/`codex` process; fixed with `unset KIND` after the lookups and reverified with a faked `claude` executable that the variable is no longer present in its environment.
- No automated tests exist for this script; validation is manual per the above.
