### PR TITLE
feat(ai): support scoped skill prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Start an interactive Codex or Claude session for a configured kind.
 Syntax:
 
 ```bash
-ai <codex|claude> <kind> [prompt...]
+ai <codex|claude> <kind> [-s <scope>] [--] [prompt...]
 ```
 
 Examples:
@@ -317,6 +317,8 @@ Examples:
 ```bash
 ai codex code "add a cache for this request"
 ai claude test-gaps "focus on the command-line interface"
+ai codex test-gaps -s lib "focus on the command-line interface"
+ai codex code -- "-s this is a literal prompt"
 ```
 
 The model, reasoning level, and prompt preamble are configured in
@@ -332,7 +334,7 @@ kinds:
     claude:
       model: opus
       effort: xhigh
-    preamble: Inspect this repository with agents and a goal.
+    preamble: with agents and a goal
 ```
 
 `code` has no injected preamble (`preamble: "-"`) and is not a `bin` skill, so
@@ -342,9 +344,12 @@ directory exists, so new shared skills work with `ai` without editing this
 file. Add a kind-specific entry only to override the default model,
 reasoning, or preamble for that skill.
 
-Each configured kind starts with `$<kind>` for Codex or `/<kind>` for Claude,
-followed by its preamble and then the optional prompt. The selected skill must
-already be available in the repository where you run `ai`.
+Each configured skill kind starts with `$<kind>` for Codex or `/<kind>` for
+Claude, followed by `in <scope>` and its preamble. The scope defaults to `.`
+and can be overridden with `-s <scope>` (or the long-form alias `--scope
+<scope>`). Use `--` before the prompt when it begins with `-s` or `--scope`.
+A `preamble: "-"` entry remains unscoped and rejects scope options. The
+selected skill must already be available in the repository where you run `ai`.
 
 ### 🚀 `create-ci`
 

--- a/ai
+++ b/ai
@@ -11,7 +11,7 @@ skills_dir="$script_dir/bin/skills"
 readonly skills_dir
 
 usage() {
-  echo "usage: ai <codex|claude> <kind> [prompt...]" >&2
+  echo "usage: ai <codex|claude> <kind> [-s <scope>] [prompt...]" >&2
   exit 1
 }
 
@@ -22,6 +22,29 @@ fi
 readonly provider=$1
 readonly kind=$2
 shift 2
+
+scope=.
+scope_provided=false
+while [ $# -gt 0 ]; do
+  case $1 in
+  -s | --scope)
+    if [ $# -lt 2 ] || [ -z "$2" ]; then
+      usage
+    fi
+    scope=$2
+    scope_provided=true
+    shift 2
+    ;;
+  --)
+    shift
+    break
+    ;;
+  *)
+    break
+    ;;
+  esac
+done
+readonly scope scope_provided
 
 case $provider in
 codex | claude)
@@ -80,7 +103,13 @@ if [ -z "$model" ] || [ "$model" = null ] || [ -z "$reasoning" ] || [ "$reasonin
 fi
 
 if [ "$preamble" = '-' ]; then
+  if [ "$scope_provided" = true ]; then
+    echo "scope is not supported for kind: $kind" >&2
+    exit 1
+  fi
   preamble=
+else
+  preamble="in $scope $preamble"
 fi
 
 prompt=$*

--- a/config/ai.yml
+++ b/config/ai.yml
@@ -38,4 +38,4 @@ kinds:
     claude:
       model: opus
       effort: xhigh
-    preamble: Inspect this repository with agents and a goal.
+    preamble: with agents and a goal


### PR DESCRIPTION
## What

- Add optional `-s` and `--scope` arguments to the `ai` launcher, defaulting scoped skill prompts to `.`.
- Preserve unscoped kinds, reject scope options for them, and support `--` so option-like prompts remain literal.
- Update the ai configuration and README with the scoped prompt contract and examples.
- Keep `review-pr` intentionally outside the `ai` wrapper's supported workflow; no review-pr scope handling was added.

## Why

- Align launcher-generated prompts with the shared generic skill contract while allowing callers to target a subdirectory.
- Avoid silently dropping prompt text or accepting scope options that have no effect.
- Document the compatibility-preserving command behavior for existing prompt usage.

## Testing

- `make scripts-lint` - passed
- `bash -n ai` - passed
- `yq eval '.' config/ai.yml` - passed
- `git diff --check` - passed
- Manual fake-provider argv verification covered default and custom scopes, both scope spellings, scopes containing spaces, literal option-like prompts after `--`, unscoped-kind rejection, and missing scope values.
- No automated test harness exists for `ai`; manual public-command verification was used for the changed shell behavior.

AI-assisted-by: [Codex](https://openai.com/codex/)
