### PR TITLE
feat(ai): accept prompt files for sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Start an interactive Codex or Claude session for a configured kind.
 Syntax:
 
 ```bash
-ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [--] [prompt...]
+ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-f <file>] [--] [prompt...]
 ```
 
 Examples:
@@ -319,6 +319,7 @@ ai codex code "add a cache for this request"
 ai claude test-gaps "focus on the command-line interface"
 ai codex test-gaps -s lib "focus on the command-line interface"
 ai codex test-gaps -s lib -c 95% "focus on the command-line interface"
+ai codex code --file prompts/cache.md
 ai codex code -- "-s this is a literal prompt"
 ```
 
@@ -351,8 +352,11 @@ and its preamble. The scope defaults to `.` and can be overridden with `-s
 <scope>` (or the long-form alias `--scope <scope>`). Confidence is omitted by
 default, preserving the shared `>= 90%` minimum, and can be overridden with
 `-c <confidence>` (or `--confidence <confidence>`), such as `95%`. Use `--`
-before the prompt when it begins with `-s`, `--scope`, `-c`, or `--confidence`.
-A `preamble: "-"` entry remains unscoped and rejects scope and confidence
+before the prompt when it begins with `-s`, `--scope`, `-c`, `--confidence`,
+`-f`, or `--file`. Use `-f <file>` (or `--file <file>`) to read a multiline
+prompt from a readable regular file. The file path is relative to the current
+directory, and a file prompt cannot be combined with inline prompt words. A
+`preamble: "-"` entry remains unscoped and rejects scope and confidence
 options. The selected skill must already be available in the repository where
 you run `ai`.
 

--- a/ai
+++ b/ai
@@ -9,15 +9,16 @@ readonly config_file="$script_dir/config/ai.yml"
 readonly skills_dir="$script_dir/bin/skills"
 
 usage() {
-  echo "usage: ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [--] [prompt...]" >&2
+  echo "usage: ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-f <file>] [--] [prompt...]" >&2
   exit 1
 }
 
-# Parses -s/--scope and -c/--confidence out of "$@", leaving the remaining
-# prompt words in the "prompt_args" array.
+# Parses supported flags out of "$@", leaving the remaining prompt words in
+# the "prompt_args" array.
 parse_flags() {
   scope=
   confidence=
+  prompt_file=
   while [ $# -gt 0 ]; do
     case $1 in
     -s | --scope)
@@ -32,6 +33,13 @@ parse_flags() {
         usage
       fi
       confidence=$2
+      shift 2
+      ;;
+    -f | --file)
+      if [ $# -lt 2 ] || [ -z "$2" ]; then
+        usage
+      fi
+      prompt_file=$2
       shift 2
       ;;
     --)
@@ -68,8 +76,8 @@ load_kind_config() {
 }
 
 # Builds the final "prompt" from the kind's preamble plus scope, confidence,
-# and any trailing prompt words. A preamble of "-" means the kind takes no
-# scope/confidence and no skill invocation is prepended.
+# and either a prompt file or trailing prompt words. A preamble of "-" means
+# the kind takes no scope/confidence and no skill invocation is prepended.
 build_prompt() {
   if [ "$preamble" = '-' ]; then
     if [ -n "$scope" ]; then
@@ -91,11 +99,24 @@ build_prompt() {
   fi
   readonly scope
 
-  prompt=$*
+  prompt_input=$*
+  if [ -n "$prompt_file" ]; then
+    if [ $# -gt 0 ]; then
+      echo "prompt file cannot be combined with inline prompt" >&2
+      exit 1
+    fi
+    if [ ! -f "$prompt_file" ] || [ ! -r "$prompt_file" ]; then
+      echo "unable to read prompt file: $prompt_file" >&2
+      exit 1
+    fi
+    prompt_input=$(<"$prompt_file")
+  fi
+  prompt=$prompt_input
+
   if [ -n "$preamble" ]; then
     prompt="${skill_prefix}${kind} ${preamble}"
-    if [ $# -gt 0 ]; then
-      prompt="$prompt"$'\n\n'"$*"
+    if [ $# -gt 0 ] || [ -n "$prompt_file" ]; then
+      prompt="$prompt"$'\n\n'"$prompt_input"
     fi
   fi
 }


### PR DESCRIPTION
## What

- Adds `-f` and `--file` prompt input to `ai` while preserving inline prompt usage.
- Reads multiline file prompts as one provider argument and keeps configured skill preambles in front of them.
- Rejects unreadable prompt files and combinations of file and inline prompt sources, with README usage documentation.

## Why

- Long or multiline prompts are cumbersome as shell arguments; file input provides a concise, repeatable way to start Codex or Claude sessions without changing existing invocations.

## Testing

- `make scripts-lint` - passed.
- `make lint` - passed with 2 Ruby files inspected and no offenses.
- `make sec` - passed with no vulnerabilities or secrets detected in the scanned Gemfile.lock.
- `git diff --check` - passed.
- Manual provider-stub scenarios for Codex and Claude covered multiline file content, preamble composition, and mixed file/inline prompt rejection.
