### PR TITLE
feat(update-buf-dep): refresh pinned remote plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ include bin/build/make/codex.mak
 
 # Lint all shell scripts.
 scripts-lint:
-	@shellcheck ai clean create-ci deps load lsp rotate-ci rotate-oauth-ci update update-bundler update-ci update-docker-dep update-root update-ruby update-ruby-dep update-service update-service-dep update-submodule lib/dirs.sh lib/slugs.sh lib/version.sh
+	@shellcheck ai clean create-ci deps load lsp rotate-ci rotate-oauth-ci update update-buf update-buf-dep update-bundler update-ci update-docker-dep update-root update-ruby update-ruby-dep update-service update-service-dep update-submodule lib/dirs.sh lib/slugs.sh lib/version.sh

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Top-level scripts:
 - `rotate-ci`: rotate GitHub OAuth CircleCI triggers for slugs in `lib/slugs.sh`.
 - `rotate-oauth-ci`: rotate one GitHub OAuth CircleCI trigger.
 - `update`: run bulk actions over a directory set (`ruby`, `go`, `services`, `all`).
+- `update-buf`: run Buf-related bulk actions over configured repository sets.
+- `update-buf-dep`: update pinned Buf remote plugins and regenerate outputs.
 - `update-bundler`: install a Bundler version and run follow-up make targets.
 - `update-ci`: update CircleCI image tags to latest published Docker Hub tags.
 - `update-docker-dep`: bump a package in the local `alexfalkowski/docker` repo.
@@ -64,13 +66,14 @@ Additional requirements by script:
 - `rotate-oauth-ci`: `curl`, `jq`
 - `update-bundler` and the `update-ruby ... bundler` action: `ruby`, RubyGems
   (`gem`)
+- `update-buf-dep`: `buf`, `curl`, `jq`, `yq`
 - `update-ci`: `curl`, `jq`, GNU `sed`, GNU `sort`
 - `update-docker-dep`: `awk`, GNU `sed`
 - `update-go-dep`: `ruby`
 - `update-root`: `awk`, `find`
 
 > [!IMPORTANT]
-> Bulk scripts (`update`, `update-service`, `update-ruby`, and `rotate-ci`) call
+> Bulk scripts (`update`, `update-buf`, `update-service`, `update-ruby`, and `rotate-ci`) call
 > other scripts by command name after changing directories or iterating configured
 > slugs. Add this repository to `PATH` so those commands resolve correctly.
 
@@ -129,7 +132,7 @@ repository Trivy scan through the shared `bin` submodule.
 
 ## 🧭 Directory sets used by bulk scripts
 
-`update`, `update-service`, and `update-ruby` read directories from
+`update`, `update-buf`, `update-service`, and `update-ruby` read directories from
 [`lib/dirs.sh`](lib/dirs.sh).
 
 Defined arrays:
@@ -152,7 +155,7 @@ Bulk scripts run their actions inside every configured target repository. When
 a script finalizes with `make ready`, the shared Git workflow commits all
 changes, force-pushes the current branch with a lease, opens a GitHub PR, and
 enables auto squash-merge. This applies directly or transitively to
-`update-ci`, `update-bundler`, `update-ruby-dep`, `update-service-dep`,
+`update-buf-dep`, `update-ci`, `update-bundler`, `update-ruby-dep`, `update-service-dep`,
 `update-docker-dep`, `update-root`, and `update-submodule`.
 
 `done` actions run `make done` in each target repository. That shared workflow
@@ -229,6 +232,16 @@ This runs submodule updates in each configured repo and finalizes with
 ```
 
 Replace `<version>` with the Bundler version you intend to roll out.
+
+### 🧬 Update Buf remote plugins
+
+```bash
+./update-buf all new svc "update Buf dependencies"
+./update-buf all done
+```
+
+This only updates repositories with a Buf-enabled Makefile and pinned remote
+plugins in `buf.gen.yaml`.
 
 ### 💠 Upgrade Bundler in one target repo
 
@@ -589,6 +602,65 @@ Examples:
 ./update-ruby services bundler 2.5.6 "upgrade bundler"
 ./update-ruby all done
 ```
+
+### 🧬 `update-buf`
+
+Run Buf dependency actions across configured repositories.
+
+Syntax:
+
+```bash
+./update-buf <dirs> <action> [args...]
+```
+
+`<dirs>`:
+
+- `ruby`
+- `go`
+- `services`
+- `all`
+
+Actions:
+
+- `new`: `update-buf-dep <kind> <desc>`
+- `done`: `make done`
+
+Examples:
+
+```bash
+./update-buf all new svc "update Buf dependencies"
+./update-buf all done
+```
+
+### 🧬 `update-buf-dep`
+
+Run inside a target repository.
+
+Syntax:
+
+```bash
+update-buf-dep <kind> <desc>
+```
+
+Example:
+
+```bash
+update-buf-dep svc "update Buf dependencies"
+```
+
+Behavior:
+
+- Finds each `Makefile` that includes `bin/build/make/buf.mak`, including
+  relative-path variants.
+- Skips the repository when no matching directory contains `buf.gen.yaml` with
+  a pinned `buf.build/...:<version>` remote plugin.
+- Resolves each pinned remote plugin to its latest Buf version without writing
+  generated output during resolution.
+- Starts `make name=deps new-<kind>` only when a plugin version changes.
+- Updates `buf.gen.yaml`, then runs `make -C <dir> update-all-dep` and
+  `make -C <dir> generate` for every changed Buf directory.
+- Finalizes with
+  `make msg="updated buf dependencies" desc="<desc>" ready`.
 
 ### 💠 `update-bundler`
 

--- a/update-buf
+++ b/update-buf
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1010,SC1091,SC2154
+
+# Runs Buf dependency updates across configured repository sets.
+set -eo pipefail
+
+source "$(dirname "$0")"/lib/dirs.sh
+readonly dirs=$1
+readonly action=$2
+
+case $dirs in
+ruby)
+  readonly directories=("${ruby[@]}")
+  ;;
+
+go)
+  readonly directories=("${go[@]}")
+  ;;
+
+services)
+  readonly directories=("${services[@]}")
+  ;;
+
+all)
+  readonly directories=("${all[@]}")
+  ;;
+esac
+
+case $action in
+new)
+  for dir in "${directories[@]}"; do
+    (cd "$dir" && update-buf-dep "$3" "$4")
+  done
+  ;;
+
+done)
+  for dir in "${directories[@]}"; do
+    (cd "$dir" && make done)
+  done
+  ;;
+esac

--- a/update-buf-dep
+++ b/update-buf-dep
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Updates pinned Buf remote plugins and regenerates their outputs.
+set -eo pipefail
+
+readonly kind=$1
+readonly desc=$2
+
+declare -a configs
+declare -a remotes
+declare -a latest_remotes
+declare -a processed_configs
+
+latest_remote_plugin() {
+  local remote=$1
+  local plugin_path
+  local owner
+  local name
+  local latest_version
+
+  plugin_path="${remote%:*}"
+  plugin_path="${plugin_path#buf.build/}"
+  owner="${plugin_path%%/*}"
+  name="${plugin_path#*/}"
+  latest_version="$(
+    jq -n --arg owner "$owner" --arg name "$name" '{owner: $owner, name: $name}' |
+      curl --fail --silent --show-error --http1.1 \
+        --header 'Content-Type: application/json' \
+        --header 'Connect-Protocol-Version: 1' \
+        --header 'Accept: application/json' \
+        --data @- \
+        https://buf.build/buf.alpha.registry.v1alpha1.PluginCurationService/GetLatestCuratedPlugin |
+      jq -er '.plugin.version'
+  )"
+
+  printf '%s:%s\n' "${remote%:*}" "$latest_version"
+}
+
+while IFS= read -r -d '' makefile; do
+  dir="$(dirname "$makefile")"
+  config="${dir}/buf.gen.yaml"
+
+  [ -f "$config" ] || continue
+
+  while IFS= read -r remote; do
+    latest_remote="$(latest_remote_plugin "$remote")"
+
+    configs+=("$config")
+    remotes+=("$remote")
+    latest_remotes+=("$latest_remote")
+  done < <(yq -r '.plugins[]? | select((.remote // "") | test("^buf\\.build/.+:[^:]+$")) | .remote' "$config")
+done < <(rg -l -0 '^[[:space:]]*-?include[[:space:]]+.*bin/build/make/buf\.mak([[:space:]]|$)' -g Makefile)
+
+changed=false
+for index in "${!configs[@]}"; do
+  [ "${remotes[$index]}" = "${latest_remotes[$index]}" ] || changed=true
+done
+
+[ "$changed" = true ] || exit 0
+
+make name=deps new-"${kind}"
+
+for config_index in "${!configs[@]}"; do
+  config="${configs[$config_index]}"
+
+  for processed_config in "${processed_configs[@]}"; do
+    [ "$config" = "$processed_config" ] && continue 2
+  done
+
+  processed_configs+=("$config")
+  dir="$(dirname "$config")"
+  changed=false
+
+  for index in "${!configs[@]}"; do
+    [ "$config" = "${configs[$index]}" ] || continue
+    [ "${remotes[$index]}" = "${latest_remotes[$index]}" ] && continue
+
+    remote="${remotes[$index]}" latest_remote="${latest_remotes[$index]}" yq -i '(.plugins[] | select(.remote == strenv(remote))).remote = strenv(latest_remote)' "$config"
+    changed=true
+  done
+
+  "$changed" || continue
+
+  make -C "$dir" update-all-dep
+  make -C "$dir" generate
+done
+
+make msg="updated buf dependencies" desc="${desc}" ready


### PR DESCRIPTION
## What

- Adds `update-buf-dep` to find Buf-enabled directories, refresh pinned public remote plugin versions, update Buf dependencies, and regenerate outputs.
- Adds `update-buf` bulk `new` and `done` workflows across the configured Ruby, Go, service, and all repository sets.
- Documents the commands, prerequisites, workflow side effects, and validates the new scripts with ShellCheck.

## Why

- Keeps remote protobuf code generators current through the same repeatable maintenance workflow as the existing dependency helpers.
- Skips repositories without a matching Buf configuration and avoids creating a branch when every pinned version is already current.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make lint` - passed
- `make sec` - passed
- Controlled consumer-style fixtures - passed: update Go and Ruby plugins, run each requested Make target once per changed Buf directory, and skip missing `buf.gen.yaml`.

AI-assisted-by: [Codex](https://openai.com/codex/)
