### PR TITLE
feat(ai): display scoped ledger entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Syntax:
 
 ```bash
 ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-f <file>] [--] [prompt...]
+ai ledger <kind> [-s <scope>] [<ledger-id>]
 ```
 
 Examples:
@@ -333,6 +334,8 @@ ai claude test-gaps "focus on the command-line interface"
 ai codex test-gaps -s lib "focus on the command-line interface"
 ai codex test-gaps -s lib -c 95% "focus on the command-line interface"
 ai codex go -s lib ISSUE-1/2/3
+ai ledger code-issues -s lib
+ai ledger code-issues -s lib ISSUE-12
 ai codex code --file prompts/cache.md
 ai codex code -- "-s this is a literal prompt"
 ```
@@ -378,6 +381,13 @@ Ledger skills load their skill-owned `ledger.yaml` contract and add the exact
 ledger path derived from the selected scope to the generated prompt. For
 example, `code-issues -s lib` supplies `lib/ISSUES.md`, so an approved entry
 does not need to search for its ledger.
+
+Use `ai ledger <kind> [-s <scope>] [<ledger-id>]` to render a skill's scoped
+ledger with `glow`. The scope defaults to `.`, and the kind must define a
+readable `ledger.yaml` contract. For example, `ai ledger code-issues -s lib`
+renders `lib/ISSUES.md`, while `ai ledger code-issues -s lib ISSUE-12` renders
+only the `ISSUE-12` entry. The ID must use the selected skill's configured
+prefix and a numeric suffix.
 
 `go` is a ledger-only shortcut that accepts one ID or compact same-prefix batch,
 resolves its skill from the contract's `id_prefix`, and expands it to the

--- a/ai
+++ b/ai
@@ -10,6 +10,7 @@ readonly skills_dir="$script_dir/bin/skills"
 
 usage() {
   echo "usage: ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-f <file>] [--] [prompt...]" >&2
+  echo "       ai ledger <kind> [-s <scope>] [<ledger-id>]" >&2
   exit 1
 }
 
@@ -153,6 +154,61 @@ resolve_ledger() {
   fi
 }
 
+# Renders the selected skill's scoped ledger with glow.
+view_ledger() {
+  kind=$1
+  shift
+
+  parse_flags "$@"
+  if [ -n "$confidence" ] || [ -n "$prompt_file" ] || [ "${#prompt_args[@]}" -gt 1 ]; then
+    usage
+  fi
+
+  if ! command -v yq >/dev/null 2>&1; then
+    echo "yq is required to read ledger contracts" >&2
+    exit 1
+  fi
+
+  load_ledger_contract
+  if [ -z "$ledger_filename" ]; then
+    echo "kind does not define a ledger: $kind" >&2
+    exit 1
+  fi
+  resolve_ledger
+
+  ledger_id=${prompt_args[0]}
+  if [ -n "$ledger_id" ]; then
+    ledger_id_prefix=$(yq eval '.id_prefix' "$ledger_contract")
+    entry_number=${ledger_id#"$ledger_id_prefix"-}
+    if [ -z "$ledger_id_prefix" ] || [ "$ledger_id_prefix" = null ] || [ "$entry_number" = "$ledger_id" ] || [ -z "$entry_number" ] || [[ $entry_number = *[!0-9]* ]]; then
+      echo "invalid ledger ID: $ledger_id" >&2
+      exit 1
+    fi
+  fi
+
+  if ! command -v glow >/dev/null 2>&1; then
+    echo "glow is required to view $resolved_ledger" >&2
+    exit 1
+  fi
+
+  if [ -n "$ledger_id" ]; then
+    awk -v id="$ledger_id" '
+      found && /^## / { exit }
+      $0 ~ "^## " id "(:|[[:space:]]|$)" { found = 1 }
+      found { print }
+      END {
+        if (!found) {
+          printf "ledger entry not found: %s\n", id > "/dev/stderr"
+          exit 1
+        }
+      }
+    ' "$resolved_ledger" | glow -- -
+    return
+  fi
+
+  exec glow -- "$resolved_ledger"
+}
+
 # Builds the final "prompt" from the kind's preamble plus scope, confidence,
 # and either a prompt file or trailing prompt words. A preamble of "-" means
 # the kind takes no scope/confidence and no skill invocation is prepended.
@@ -218,63 +274,79 @@ build_command() {
   fi
 }
 
-if [ $# -lt 2 ]; then
-  usage
-fi
+main() {
+  if [ $# -lt 1 ]; then
+    usage
+  fi
 
-readonly provider=$1
-kind=$2
-shift 2
+  if [ "$1" = ledger ]; then
+    if [ $# -lt 2 ]; then
+      usage
+    fi
+    view_ledger "$2" "${@:3}"
+    return
+  fi
 
-parse_flags "$@"
+  if [ $# -lt 2 ]; then
+    usage
+  fi
 
-case $provider in
-codex | claude)
-  ;;
-*)
-  echo "unknown provider: $provider" >&2
-  exit 1
-  ;;
-esac
+  readonly provider=$1
+  kind=$2
+  shift 2
 
-if [ ! -r "$config_file" ]; then
-  echo "unable to read configuration: $config_file" >&2
-  exit 1
-fi
+  parse_flags "$@"
 
-if ! command -v yq >/dev/null 2>&1; then
-  echo "yq is required to read $config_file" >&2
-  exit 1
-fi
+  case $provider in
+  codex | claude)
+    ;;
+  *)
+    echo "unknown provider: $provider" >&2
+    exit 1
+    ;;
+  esac
 
-if [ "$kind" = go ]; then
-  resolve_go_kind
-fi
-readonly kind
-set -- "${prompt_args[@]}"
+  if [ ! -r "$config_file" ]; then
+    echo "unable to read configuration: $config_file" >&2
+    exit 1
+  fi
 
-load_kind_config
-load_ledger_contract
+  if ! command -v yq >/dev/null 2>&1; then
+    echo "yq is required to read $config_file" >&2
+    exit 1
+  fi
 
-case $provider in
-codex)
-  model=$codex_model
-  reasoning=$codex_reasoning
-  skill_prefix='$'
-  ;;
-claude)
-  model=$claude_model
-  reasoning=$claude_effort
-  skill_prefix='/'
-  ;;
-esac
+  if [ "$kind" = go ]; then
+    resolve_go_kind
+  fi
+  readonly kind
+  set -- "${prompt_args[@]}"
 
-if [ -z "$model" ] || [ "$model" = null ] || [ -z "$reasoning" ] || [ "$reasoning" = null ]; then
-  echo "unknown kind: $kind" >&2
-  exit 1
-fi
+  load_kind_config
+  load_ledger_contract
 
-build_prompt "$@"
-build_command
+  case $provider in
+  codex)
+    model=$codex_model
+    reasoning=$codex_reasoning
+    skill_prefix='$'
+    ;;
+  claude)
+    model=$claude_model
+    reasoning=$claude_effort
+    skill_prefix='/'
+    ;;
+  esac
 
-exec "${command[@]}"
+  if [ -z "$model" ] || [ "$model" = null ] || [ -z "$reasoning" ] || [ "$reasoning" = null ]; then
+    echo "unknown kind: $kind" >&2
+    exit 1
+  fi
+
+  build_prompt "$@"
+  build_command
+
+  exec "${command[@]}"
+}
+
+main "$@"


### PR DESCRIPTION
## What

- Add the `ai ledger` command for rendering a selected skill's scoped ledger or one numeric entry with `glow`.
- Preserve existing Codex and Claude launch behavior while rejecting unsupported flags, invalid IDs, and kinds without ledger contracts.
- Document the ledger-view command, its scoped path rules, and examples.

## Why

- Makes ledger inspection a direct maintainer action while retaining the skill-owned ledger contract and validation rules.

## Testing

- `make dep clean-dep` - passed
- `make scripts-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `bash -n ai && git diff --check` - passed
- Public `ai ledger` smoke checks - passed: successful full-ledger rendering through Glow and invalid ledger-ID rejection using a scoped fixture.
- No automated CLI test harness exists; the documented command was checked directly.
