### PR TITLE
feat(ai): separate approval prompts from finding prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ ai codex code --file prompts/cache.md
 ai codex code -- "-s this is a literal prompt"
 ```
 
-The model, reasoning level, and prompt preamble are configured in
+The model, reasoning level, and mode-specific prompt preambles are configured in
 [`config/ai.yml`](config/ai.yml), read with `yq`. Each entry under `kinds`
 looks like this:
 
@@ -353,23 +353,27 @@ kinds:
     claude:
       model: opus
       effort: xhigh
-    preamble: with agents and a goal
+    find_preamble: with agents and a goal
+    approval_preamble: with agents and a goal
 ```
 
-`code` has no injected preamble (`preamble: "-"`) and is not a `bin` skill, so
-it always needs its own entry. Any other kind that has no entry of its own
-falls back to `kinds.default` as long as a matching `bin/skills/<kind>`
-directory exists, so new shared skills work with `ai` without editing this
-file. Add a kind-specific entry only to override the default model,
-reasoning, or preamble for that skill.
+Ledger kinds use `find_preamble` for normal finding requests and
+`approval_preamble` for the `go` approval shortcut. Other kinds use
+`preamble`; `code` has no injected preamble (`preamble: "-"`) and is not a
+`bin` skill, so it always needs its own entry. Any other kind that has no entry
+of its own falls back to `kinds.default` as long as a matching
+`bin/skills/<kind>` directory exists, so new shared skills work with `ai`
+without editing this file. Add a kind-specific entry only to override the
+default model, reasoning, or preamble for that skill.
 
 Each configured skill kind starts with `$<kind>` for Codex or `/<kind>` for
 Claude, followed by `in <scope>`, an optional `with >= <confidence> confidence`,
-and its preamble. The scope defaults to `.` and can be overridden with `-s
-<scope>` (or the long-form alias `--scope <scope>`). Confidence is omitted by
-default, preserving the shared `>= 90%` minimum, and can be overridden with
-`-c <confidence>` (or `--confidence <confidence>`), such as `95%`. Use `--`
-before the prompt when it begins with `-s`, `--scope`, `-c`, `--confidence`,
+and its find or generic preamble. The scope defaults to `.` and can be
+overridden with `-s <scope>` (or the long-form alias `--scope <scope>`).
+Confidence is omitted by default, preserving the shared `>= 90%` minimum, and
+can be overridden with `-c <confidence>` (or `--confidence <confidence>`),
+such as `95%`. Use `--` before the prompt when it begins with `-s`, `--scope`,
+`-c`, `--confidence`,
 `-f`, or `--file`. Use `-f <file>` (or `--file <file>`) to read a multiline
 prompt from a readable regular file. The file path is relative to the current
 directory, and a file prompt cannot be combined with inline prompt words. A
@@ -393,9 +397,9 @@ prefix and a numeric suffix.
 resolves its skill from the contract's `id_prefix`, and expands it to the
 canonical `Approved ID` prompt. For example, `ai codex go -s lib ISSUE-1/2/3`
 runs `code-issues` against `lib/ISSUES.md` and forwards
-`Approved ISSUE-1/2/3` unchanged. The skill owns the batch's sequential
-validation and stop behavior; the resolved skill's configured model, reasoning
-level, and preamble still apply.
+`Approved ISSUE-1/2/3 in lib/ISSUES.md with agents and a goal`. The skill owns
+the batch's sequential validation and stop behavior; the resolved skill's
+configured model, reasoning level, and approval preamble still apply.
 
 ### 🚀 `create-ci`
 

--- a/ai
+++ b/ai
@@ -56,7 +56,7 @@ parse_flags() {
 }
 
 # Resolves the kind's yq base path, falling back to .kinds.default for any
-# kind with a skills directory, then reads its model/reasoning/preamble.
+# kind with a skills directory, then reads its model/reasoning/prompt preamble.
 load_kind_config() {
   export KIND=$kind
   if [ "$(yq eval '.kinds | has(env(KIND))' "$config_file")" = true ]; then
@@ -72,7 +72,8 @@ load_kind_config() {
   codex_reasoning=$(yq eval "${base}.codex.reasoning" "$config_file")
   claude_model=$(yq eval "${base}.claude.model" "$config_file")
   claude_effort=$(yq eval "${base}.claude.effort" "$config_file")
-  preamble=$(yq eval "${base}.preamble" "$config_file")
+  preamble=$(yq eval "${base}.find_preamble // ${base}.preamble" "$config_file")
+  approval_preamble=$(yq eval "${base}.approval_preamble // ${base}.preamble" "$config_file")
   unset KIND
 }
 
@@ -247,6 +248,11 @@ build_prompt() {
   fi
   prompt=$prompt_input
 
+  if [ "$prompt_mode" = approval ]; then
+    prompt="$prompt_input in $resolved_ledger $approval_preamble"
+    return
+  fi
+
   if [ -n "$preamble" ]; then
     prompt="${skill_prefix}${kind} ${preamble}"
     if [ -n "$resolved_ledger" ]; then
@@ -275,6 +281,8 @@ build_command() {
 }
 
 main() {
+  prompt_mode=standard
+
   if [ $# -lt 1 ]; then
     usage
   fi
@@ -317,9 +325,9 @@ main() {
   fi
 
   if [ "$kind" = go ]; then
+    prompt_mode=approval
     resolve_go_kind
   fi
-  readonly kind
   set -- "${prompt_args[@]}"
 
   load_kind_config

--- a/config/ai.yml
+++ b/config/ai.yml
@@ -1,5 +1,7 @@
 # Read by `ai`. Each kind configures the Codex and Claude model/reasoning
-# level to use, plus a prompt preamble.
+# level to use, plus mode-specific prompt preambles. `find_preamble` applies
+# to ledger-find invocations; `approval_preamble` applies to the `go` approval
+# shortcut.
 #
 # Use "-" as a kind's preamble when it should not invoke a provider skill.
 #
@@ -14,10 +16,11 @@ profiles:
     claude:
       model: opus
       effort: xhigh
-    preamble: >-
+    find_preamble: >-
       with agents and a goal. Record confirmed findings in the ledger, update
       .gitignore only if required, report findings or none, then stop—no next
       steps or implementation offers.
+    approval_preamble: with agents and a goal
 kinds:
   code:
     codex:
@@ -64,3 +67,4 @@ kinds:
       model: opus
       effort: xhigh
     preamble: with agents and a goal
+    approval_preamble: with agents and a goal


### PR DESCRIPTION
## What

- Separate ledger finding and approval prompt preambles so the `go` shortcut forwards a scoped `Approved` instruction with the configured approval guidance.
- Preserve existing per-kind `preamble` overrides when an `approval_preamble` has not yet been configured.
- Document the two prompt modes and the generated ledger-approval prompt.

## Why

- Finding workflows need their detailed ledger instructions, while approval workflows need a focused instruction that can proceed from the resolved ledger entry.
- The fallback keeps existing local configuration overrides working during the transition to mode-specific preambles.

## Testing

- `make scripts-lint` - passed
- `yq eval '.' config/ai.yml` - passed
- `make sec` - passed
- No established functional harness exercises generated `ai` prompts; repository-defined lint, configuration parsing, security scanning, and manual command-flow review were used.

AI-assisted-by: [Codex](https://openai.com/codex/)
