### PR TITLE
feat(ai): keep ledger locations out of finding prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,10 +381,10 @@ directory, and a file prompt cannot be combined with inline prompt words. A
 options. The selected skill must already be available in the repository where
 you run `ai`.
 
-Ledger skills load their skill-owned `ledger.yaml` contract and add the exact
-ledger path derived from the selected scope to the generated prompt. For
-example, `code-issues -s lib` supplies `lib/ISSUES.md`, so an approved entry
-does not need to search for its ledger.
+Ledger skills own a `ledger.yaml` contract that maps the selected scope to a
+canonical ledger path. The skill resolves that path when needed; normal `ai`
+prompts do not repeat it. The `go` approval shortcut resolves the path when it
+builds its canonical `Approved` command.
 
 Use `ai ledger <kind> [-s <scope>] [<ledger-id>]` to render a skill's scoped
 ledger with `glow`. The scope defaults to `.`, and the kind must define a

--- a/ai
+++ b/ai
@@ -121,8 +121,7 @@ resolve_go_kind() {
   prompt_args=("Approved $ledger_id")
 }
 
-# Loads the selected skill's optional ledger contract so the model receives
-# the exact scoped ledger path without searching the workspace.
+# Loads the selected skill's optional ledger contract for path resolution.
 load_ledger_contract() {
   ledger_contract="$skills_dir/$kind/ledger.yaml"
   ledger_filename=
@@ -255,9 +254,6 @@ build_prompt() {
 
   if [ -n "$preamble" ]; then
     prompt="${skill_prefix}${kind} ${preamble}"
-    if [ -n "$resolved_ledger" ]; then
-      prompt="$prompt"$'\n\n'"Exact ledger path: $resolved_ledger"
-    fi
     if [ $# -gt 0 ] || [ -n "$prompt_file" ]; then
       prompt="$prompt"$'\n\n'"$prompt_input"
     fi


### PR DESCRIPTION
## What

- Keep canonical ledger paths out of standard finding prompts while retaining them in the `go` approval command.
- Align the `ai` wrapper documentation with the mode-specific prompt behavior.

## Why

- Finding skills resolve their own scoped ledger when needed, while approval workflows need the explicit ledger location to process the selected entry.

## Testing

- `make scripts-lint` - passed
- `make lint` - passed
- `make sec` - passed
- Static review covered normal and approval prompt construction. A live prompt-capture probe was blocked because the installed Codex client could not open its local state database in this sandbox.

AI-assisted-by: [Codex](https://openai.com/codex/)
