### PR TITLE
feat(ai): isolate interactive shell startup state

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Base requirements:
 
 Additional requirements by script:
 
-- `ai`: `yq`, plus Codex CLI (`codex`) and/or Claude Code (`claude`), depending
+- `ai`: `yq`, `zsh`, plus Codex CLI (`codex`) and/or Claude Code (`claude`), depending
   on the selected provider
 - `create-ci`: `curl`, `CIRCLECI_API_TOKEN`, `CODECOV_TOKEN`
 - `deps`: `go`

--- a/ai
+++ b/ai
@@ -276,6 +276,13 @@ build_command() {
   fi
 }
 
+# Removes the per-launch Zsh cache while retaining the requested command's status.
+cleanup_zsh_cache() {
+  local exit_status=$?
+  rm -rf -- "$zsh_cache_dir" || :
+  exit "$exit_status"
+}
+
 main() {
   prompt_mode=standard
 
@@ -320,6 +327,11 @@ main() {
     exit 1
   fi
 
+  if ! command -v zsh >/dev/null 2>&1; then
+    echo "zsh is required to start $provider sessions" >&2
+    exit 1
+  fi
+
   if [ "$kind" = go ]; then
     prompt_mode=approval
     resolve_go_kind
@@ -350,7 +362,15 @@ main() {
   build_prompt "$@"
   build_command
 
-  exec "${command[@]}"
+  zsh_cache_dir="$(mktemp -d "${TMPDIR:-/tmp}/ai-zsh-cache.XXXXXX")" || {
+    echo "unable to create temporary Zsh cache directory" >&2
+    exit 1
+  }
+  trap cleanup_zsh_cache EXIT
+  export ZSH_CACHE_DIR="$zsh_cache_dir"
+  export ZSH_COMPDUMP="$zsh_cache_dir/.zcompdump"
+
+  zsh -lic 'exec "$@"' zsh "${command[@]}"
 }
 
 main "$@"


### PR DESCRIPTION
## What

- Launch configured provider sessions through login Zsh with temporary cache locations that are cleaned up after the provider exits.
- Fail clearly when Zsh or temporary cache storage is unavailable, and list Zsh as an `ai` dependency.

## Why

- Provider CLIs need the maintainer's initialized login-shell environment, while unavailable shell prerequisites or temporary storage previously produced opaque startup failures.
- Standard Zsh `compinit` cache redirection remains intentionally out of scope to avoid changing users' startup configuration.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `bash -n ai` - passed
- `TMPDIR=<unavailable path> /bin/bash ./ai codex code` - passed; verified the expected temporary-cache diagnostic without launching a provider.

AI-assisted-by: [Codex](https://openai.com/codex/)
