### PR TITLE
feat(ai): use dedicated approval session settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,10 +358,13 @@ kinds:
 ```
 
 Ledger kinds use `find_preamble` for normal finding requests and
-`approval_preamble` for the `go` approval shortcut. Other kinds use
-`preamble`; `code` has no injected preamble (`preamble: "-"`) and is not a
-`bin` skill, so it always needs its own entry. Any other kind that has no entry
-of its own falls back to `kinds.default` as long as a matching
+`approval_preamble` for the `go` approval shortcut. The dedicated `go` entry
+sets the provider model and reasoning level for every `go` invocation, while
+the ledger kind resolved from its ID still supplies the prompt and approval
+preamble. Other kinds use `preamble`; `code` has no injected preamble
+(`preamble: "-"`) and is not a `bin` skill, so it always needs its own entry.
+Any other kind that has no entry of its own falls back to `kinds.default` as
+long as a matching
 `bin/skills/<kind>` directory exists, so new shared skills work with `ai`
 without editing this file. Add a kind-specific entry only to override the
 default model, reasoning, or preamble for that skill.
@@ -399,7 +402,8 @@ canonical `Approved ID` prompt. For example, `ai codex go -s lib ISSUE-1/2/3`
 runs `code-issues` against `lib/ISSUES.md` and forwards
 `Approved ISSUE-1/2/3 in lib/ISSUES.md with agents and a goal`. The skill owns
 the batch's sequential validation and stop behavior; the resolved skill's
-configured model, reasoning level, and approval preamble still apply.
+approval preamble still applies, while the dedicated `go` model settings are
+used for the session.
 
 ### 🚀 `create-ci`
 

--- a/ai
+++ b/ai
@@ -56,7 +56,7 @@ parse_flags() {
 }
 
 # Resolves the kind's yq base path, falling back to .kinds.default for any
-# kind with a skills directory, then reads its model/reasoning/prompt preamble.
+# kind with a skills directory, then reads its provider settings and preamble.
 load_kind_config() {
   export KIND=$kind
   if [ "$(yq eval '.kinds | has(env(KIND))' "$config_file")" = true ]; then
@@ -68,10 +68,18 @@ load_kind_config() {
     exit 1
   fi
 
-  codex_model=$(yq eval "${base}.codex.model" "$config_file")
-  codex_reasoning=$(yq eval "${base}.codex.reasoning" "$config_file")
-  claude_model=$(yq eval "${base}.claude.model" "$config_file")
-  claude_effort=$(yq eval "${base}.claude.effort" "$config_file")
+  if [ "$prompt_mode" = approval ]; then
+    codex_model=$(yq eval '.kinds.go.codex.model' "$config_file")
+    codex_reasoning=$(yq eval '.kinds.go.codex.reasoning' "$config_file")
+    claude_model=$(yq eval '.kinds.go.claude.model' "$config_file")
+    claude_effort=$(yq eval '.kinds.go.claude.effort' "$config_file")
+  else
+    codex_model=$(yq eval "${base}.codex.model" "$config_file")
+    codex_reasoning=$(yq eval "${base}.codex.reasoning" "$config_file")
+    claude_model=$(yq eval "${base}.claude.model" "$config_file")
+    claude_effort=$(yq eval "${base}.claude.effort" "$config_file")
+  fi
+
   preamble=$(yq eval "${base}.find_preamble // ${base}.preamble" "$config_file")
   approval_preamble=$(yq eval "${base}.approval_preamble // ${base}.preamble" "$config_file")
   unset KIND

--- a/config/ai.yml
+++ b/config/ai.yml
@@ -1,7 +1,8 @@
 # Read by `ai`. Each kind configures the Codex and Claude model/reasoning
 # level to use, plus mode-specific prompt preambles. `find_preamble` applies
 # to ledger-find invocations; `approval_preamble` applies to the `go` approval
-# shortcut.
+# shortcut. The dedicated `go` entry supplies the shortcut's model settings
+# after its ledger ID resolves to a skill kind.
 #
 # Use "-" as a kind's preamble when it should not invoke a provider skill.
 #
@@ -9,6 +10,14 @@
 # a skill directory under bin/skills/<kind>, so new shared skills work with
 # `ai` without editing this file.
 profiles:
+  code: &code
+    codex:
+      model: gpt-5.6-terra
+      reasoning: high
+    claude:
+      model: sonnet
+      effort: high
+    preamble: "-"
   ledger: &ledger
     codex:
       model: gpt-5.6-sol
@@ -22,14 +31,8 @@ profiles:
       steps or implementation offers.
     approval_preamble: with agents and a goal
 kinds:
-  code:
-    codex:
-      model: gpt-5.6-terra
-      reasoning: high
-    claude:
-      model: sonnet
-      effort: high
-    preamble: "-"
+  code: *code
+  go: *code
   code-issues: *ledger
   feature-gaps: *ledger
   project-gaps: *ledger


### PR DESCRIPTION
## What

- Ensure approval shortcut sessions use the code-oriented Codex and Claude model settings while retaining the resolved ledger skill's approval prompt.
- Document the separation between the approval session profile and the ledger kind that supplies the prompt.

## Why

- Approval actions transition from finding to implementation, so they need the code profile's provider settings without losing the ledger workflow's scoped approval instructions.

## Testing

- `make dep` - passed
- `make clean-dep` - passed
- `make scripts-lint` - passed
- `make lint` - passed
- `make sec` - passed
- Isolated Codex and Claude invocation checks confirmed approval and ordinary ledger profiles use their intended model, reasoning, and prompt values.

AI-assisted-by: [Codex](https://openai.com/codex/)
