### PR TITLE
feat(ai): allow per-session reasoning overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Start an interactive Codex or Claude session for a configured kind.
 Syntax:
 
 ```bash
-ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-f <file>] [--] [prompt...]
+ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-e <effort>] [-f <file>] [--] [prompt...]
 ai ledger <kind> [-s <scope>] [<ledger-id>]
 ```
 
@@ -333,6 +333,7 @@ ai codex code "add a cache for this request"
 ai claude test-gaps "focus on the command-line interface"
 ai codex test-gaps -s lib "focus on the command-line interface"
 ai codex test-gaps -s lib -c 95% "focus on the command-line interface"
+ai codex test-gaps -s lib --reasoning high "focus on the command-line interface"
 ai codex go -s lib ISSUE-1/2/3
 ai ledger code-issues -s lib
 ai ledger code-issues -s lib ISSUE-12
@@ -375,9 +376,11 @@ and its find or generic preamble. The scope defaults to `.` and can be
 overridden with `-s <scope>` (or the long-form alias `--scope <scope>`).
 Confidence is omitted by default, preserving the shared `>= 90%` minimum, and
 can be overridden with `-c <confidence>` (or `--confidence <confidence>`),
-such as `95%`. Use `--` before the prompt when it begins with `-s`, `--scope`,
-`-c`, `--confidence`,
-`-f`, or `--file`. Use `-f <file>` (or `--file <file>`) to read a multiline
+such as `95%`. The configured reasoning level can be overridden for one run
+with `-e <effort>`, `--effort <effort>`, or `--reasoning <effort>`. Use `--`
+before the prompt when it begins with `-s`, `--scope`, `-c`, `--confidence`,
+`-e`, `--effort`, `--reasoning`, `-f`, or `--file`. Use `-f <file>` (or
+`--file <file>`) to read a multiline
 prompt from a readable regular file. The file path is relative to the current
 directory, and a file prompt cannot be combined with inline prompt words. A
 `preamble: "-"` entry remains unscoped and rejects scope and confidence

--- a/ai
+++ b/ai
@@ -9,7 +9,7 @@ readonly config_file="$script_dir/config/ai.yml"
 readonly skills_dir="$script_dir/bin/skills"
 
 usage() {
-  echo "usage: ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-f <file>] [--] [prompt...]" >&2
+  echo "usage: ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-e <effort>] [-f <file>] [--] [prompt...]" >&2
   echo "       ai ledger <kind> [-s <scope>] [<ledger-id>]" >&2
   exit 1
 }
@@ -19,6 +19,7 @@ usage() {
 parse_flags() {
   scope=
   confidence=
+  effort=
   prompt_file=
   while [ $# -gt 0 ]; do
     case $1 in
@@ -34,6 +35,13 @@ parse_flags() {
         usage
       fi
       confidence=$2
+      shift 2
+      ;;
+    -e | --effort | --reasoning)
+      if [ $# -lt 2 ] || [ -z "$2" ]; then
+        usage
+      fi
+      effort=$2
       shift 2
       ;;
     -f | --file)
@@ -168,7 +176,7 @@ view_ledger() {
   shift
 
   parse_flags "$@"
-  if [ -n "$confidence" ] || [ -n "$prompt_file" ] || [ "${#prompt_args[@]}" -gt 1 ]; then
+  if [ -n "$confidence" ] || [ -n "$effort" ] || [ -n "$prompt_file" ] || [ "${#prompt_args[@]}" -gt 1 ]; then
     usage
   fi
 
@@ -361,6 +369,10 @@ main() {
     skill_prefix='/'
     ;;
   esac
+
+  if [ -n "$effort" ]; then
+    reasoning=$effort
+  fi
 
   if [ -z "$model" ] || [ "$model" = null ] || [ -z "$reasoning" ] || [ "$reasoning" = null ]; then
     echo "unknown kind: $kind" >&2

--- a/config/ai.yml
+++ b/config/ai.yml
@@ -21,10 +21,10 @@ profiles:
   ledger: &ledger
     codex:
       model: gpt-5.6-sol
-      reasoning: xhigh
+      reasoning: high
     claude:
       model: opus
-      effort: xhigh
+      effort: high
     find_preamble: >-
       with agents and a goal. Record confirmed findings in the ledger, update
       .gitignore only if required, report findings or none, then stop—no next


### PR DESCRIPTION
## What

- Add a one-run reasoning-effort override for Codex and Claude sessions through `-e`, `--effort`, or `--reasoning`.
- Set the shared ledger profile to `high` reasoning by default and document the new command options and prompt-delimiter behavior.

## Why

- Maintainers can tune the reasoning cost and depth for a single task without editing the shared configuration, while routine ledger work uses a lower default effort.

## Testing

- `make scripts-lint` - passed
- `make lint` - passed
- `make sec` - passed
- `./ai codex code --effort` - passed (expected usage error for a missing value)
- `codex -c 'model_reasoning_effort="high"' --help && claude --effort high --help` - passed
- No dedicated `ai` behavior harness exists; ShellCheck, provider option smoke checks, and CI cover the changed command surface.

AI-assisted-by: [Codex](https://openai.com/codex/)
