### PR TITLE
feat(ai): skip approval prompts for one session with -a/--auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Start an interactive Codex or Claude session for a configured kind.
 Syntax:
 
 ```bash
-ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-e <effort>] [-f <file>] [--] [prompt...]
+ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-e <effort>] [-f <file>] [-a] [--] [prompt...]
 ai ledger <kind> [-s <scope>] [<ledger-id>]
 ```
 
@@ -377,10 +377,13 @@ overridden with `-s <scope>` (or the long-form alias `--scope <scope>`).
 Confidence is omitted by default, preserving the shared `>= 90%` minimum, and
 can be overridden with `-c <confidence>` (or `--confidence <confidence>`),
 such as `95%`. The configured reasoning level can be overridden for one run
-with `-e <effort>`, `--effort <effort>`, or `--reasoning <effort>`. Use `--`
-before the prompt when it begins with `-s`, `--scope`, `-c`, `--confidence`,
-`-e`, `--effort`, `--reasoning`, `-f`, or `--file`. Use `-f <file>` (or
-`--file <file>`) to read a multiline
+with `-e <effort>`, `--effort <effort>`, or `--reasoning <effort>`. Use `-a`
+(or `--auto`) to skip approval prompts for one run: Claude gets
+`--dangerously-skip-permissions`, and Codex gets `--ask-for-approval never`.
+Codex's sandbox stays enabled either way; only its approval prompts are
+skipped. Use `--` before the prompt when it begins with `-s`, `--scope`, `-c`,
+`--confidence`, `-e`, `--effort`, `--reasoning`, `-f`, `--file`, `-a`, or
+`--auto`. Use `-f <file>` (or `--file <file>`) to read a multiline
 prompt from a readable regular file. The file path is relative to the current
 directory, and a file prompt cannot be combined with inline prompt words. A
 `preamble: "-"` entry remains unscoped and rejects scope and confidence

--- a/ai
+++ b/ai
@@ -9,7 +9,7 @@ readonly config_file="$script_dir/config/ai.yml"
 readonly skills_dir="$script_dir/bin/skills"
 
 usage() {
-  echo "usage: ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-e <effort>] [-f <file>] [--] [prompt...]" >&2
+  echo "usage: ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-e <effort>] [-f <file>] [-a] [--] [prompt...]" >&2
   echo "       ai ledger <kind> [-s <scope>] [<ledger-id>]" >&2
   exit 1
 }
@@ -21,6 +21,7 @@ parse_flags() {
   confidence=
   effort=
   prompt_file=
+  auto=
   while [ $# -gt 0 ]; do
     case $1 in
     -s | --scope)
@@ -50,6 +51,10 @@ parse_flags() {
       fi
       prompt_file=$2
       shift 2
+      ;;
+    -a | --auto)
+      auto=1
+      shift
       ;;
     --)
       shift
@@ -176,7 +181,7 @@ view_ledger() {
   shift
 
   parse_flags "$@"
-  if [ -n "$confidence" ] || [ -n "$effort" ] || [ -n "$prompt_file" ] || [ "${#prompt_args[@]}" -gt 1 ]; then
+  if [ -n "$confidence" ] || [ -n "$effort" ] || [ -n "$prompt_file" ] || [ -n "$auto" ] || [ "${#prompt_args[@]}" -gt 1 ]; then
     usage
   fi
 
@@ -281,9 +286,15 @@ build_command() {
   case $provider in
   codex)
     command=(codex --model "$model" -c "model_reasoning_effort=\"$reasoning\"")
+    if [ -n "$auto" ]; then
+      command+=(--ask-for-approval never)
+    fi
     ;;
   claude)
     command=(claude --model "$model" --effort "$reasoning")
+    if [ -n "$auto" ]; then
+      command+=(--dangerously-skip-permissions)
+    fi
     ;;
   esac
 


### PR DESCRIPTION
## What

- Add a `-a`/`--auto` flag to `ai` that skips approval prompts for a single session: it adds `--dangerously-skip-permissions` to the `claude` invocation and `--ask-for-approval never` to the `codex` invocation.
- Codex's sandbox stays enabled either way; `-a`/`--auto` only skips its approval prompts, not sandboxing.
- `ai ledger <kind>` continues to reject `-a`/`--auto` alongside the other session-only flags (`-c`, `-e`, `-f`), since ledger viewing takes no session flags.
- Update the README syntax line and flag documentation, including the updated `--` disambiguation list, to cover the new flag.

## Why

- Interactive sessions launched via `ai` otherwise stop for approval on every tool call, which is friction for trusted, low-risk runs where the operator wants to opt into unattended execution for one invocation.
- Keeping the flag session-scoped (not persisted in config) avoids silently weakening approval behavior for future runs.

## Testing

- `make scripts-lint` - passed
- Manual read-through of `parse_flags`, `build_command`, and `view_ledger` to confirm `-a`/`--auto` is parsed, threaded into the provider command only when set, and rejected by `ai ledger`.
- No automated test suite exists for this script (validated via shellcheck only, consistent with the other top-level scripts in this repo); no new tests added.
