### PR TITLE
docs(readme): clarify command requirements and help

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Base requirements:
 
 Additional requirements by script:
 
-- `ai`: `yq`, `zsh`, plus Codex CLI (`codex`) and/or Claude Code (`claude`), depending
-  on the selected provider
+- `ai`: `yq`, `zsh`, and `glow` (for `ai ledger`), plus Codex CLI (`codex`)
+  and/or Claude Code (`claude`), depending on the selected provider
 - `create-ci`: `curl`, `CIRCLECI_API_TOKEN`, `CODECOV_TOKEN`
 - `deps`: `go`
 - `load`: `vegeta`, `ghz`
@@ -66,7 +66,7 @@ Additional requirements by script:
 - `rotate-oauth-ci`: `curl`, `jq`
 - `update-bundler` and the `update-ruby ... bundler` action: `ruby`, RubyGems
   (`gem`)
-- `update-buf-dep`: `buf`, `curl`, `jq`, `yq`
+- `update-buf-dep`: `buf`, `curl`, `jq`, `rg`, `yq`
 - `update-ci`: `curl`, `jq`, GNU `sed`, GNU `sort`
 - `update-docker-dep`: `awk`, GNU `sed`
 - `update-go-dep`: `ruby`
@@ -355,10 +355,10 @@ kinds:
   test-gaps-find:
     codex:
       model: gpt-5.6-sol
-      reasoning: max
+      reasoning: high
     claude:
       model: opus
-      effort: xhigh
+      effort: high
     preamble: with agents and a goal
   test-gaps-implement:
     codex:

--- a/ai
+++ b/ai
@@ -175,8 +175,17 @@ show_skill_help() {
 
   printf '%s\n\n%s\n' "$display_name" "$short_description"
   printf '\nUsage:\n'
-  printf '  ai codex %s -s <scope> [prompt...]\n' "$kind"
-  printf '  ai claude %s -s <scope> [prompt...]\n' "$kind"
+  printf '  ai codex %s [options] [--] [prompt...]\n' "$kind"
+  printf '  ai claude %s [options] [--] [prompt...]\n' "$kind"
+  printf '\nOptions:\n'
+  printf '  -s, --scope <scope>             Scope (defaults to .)\n'
+  printf '  -c, --confidence <confidence>   Confidence target\n'
+  printf '  -e, --effort, --reasoning <effort>  Override reasoning level\n'
+  printf '  -f, --file <file>               Read the prompt from a file\n'
+  printf '  -a, --auto                      Skip provider approval prompts\n'
+  printf '  --                              Treat remaining arguments as prompt text\n'
+  printf '\nConstraints:\n'
+  printf '  A prompt file cannot be combined with inline prompt text.\n'
   printf '\nModels:\n'
   printf '  Codex: %s (%s)\n' "$codex_model" "$codex_reasoning"
   printf '  Claude: %s (%s)\n' "$claude_model" "$claude_effort"


### PR DESCRIPTION
## What

- Clarify the `ai help` usage, supported options, and prompt-file constraint.
- Correct prerequisite and model-profile details in the README to match the shipped scripts and configuration.

## Why

- Accurate command guidance and dependency requirements prevent avoidable setup and invocation failures for maintainers using the shared tooling.

## Testing

- `bash -n ai` - passed
- `./ai help test-gaps-find` - passed
- `make scripts-lint` - passed
- `make lint` - passed
- `make sec` - passed
- No automated help-output harness exists; the public command was verified manually.

AI-assisted-by: [Codex](https://openai.com/codex/)
