### PR TITLE
feat(ai): add a version subcommand to print the selected provider's cli version

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Syntax:
 
 ```bash
 ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-e <effort>] [-f <file>] [-a] [--] [prompt...]
+ai <codex|claude> version
 ai ledger <kind> [-s <scope>] [<ledger-id>]
 ai skills
 ai help <kind>
@@ -346,6 +347,8 @@ ai skills
 ai help doc-gaps-fix
 ai codex code --file prompts/cache.md
 ai codex code -- "-s this is a literal prompt"
+ai codex version
+ai claude version
 ```
 
 The model, reasoning level, and prompt preamble are configured in
@@ -386,6 +389,8 @@ Use `ai skills` for a concise list of the shared skills available through the
 current `bin` submodule. The list uses each skill's shared display metadata.
 Use `ai help <kind>` for the skill's launch syntax, shared guidance, configured
 Codex and Claude models, and ledger ownership when applicable.
+Use `ai <codex|claude> version` to print the selected provider CLI's own
+version, bypassing kind configuration and skill invocation.
 
 Each configured skill kind starts with `$<kind>` for Codex or `/<kind>` for
 Claude, followed by `in <scope>`, an optional `with >= <confidence> confidence`,

--- a/ai
+++ b/ai
@@ -10,6 +10,7 @@ readonly skills_dir="$script_dir/bin/skills"
 
 usage() {
   echo "usage: ai <codex|claude> <kind> [-s <scope>] [-c <confidence>] [-e <effort>] [-f <file>] [-a] [--] [prompt...]" >&2
+  echo "       ai <codex|claude> version" >&2
   echo "       ai ledger <kind> [-s <scope>] [<ledger-id>]" >&2
   echo "       ai skills" >&2
   echo "       ai help <kind>" >&2
@@ -438,6 +439,14 @@ run_provider_session() {
   readonly provider=$1
   kind=$2
   shift 2
+
+  if [ "$kind" = version ]; then
+    validate_provider
+    if [ $# -ne 0 ]; then
+      usage
+    fi
+    exec "$provider" --version
+  fi
 
   parse_flags "$@"
 


### PR DESCRIPTION
## What

- Adds a new `ai <codex|claude> version` command that execs the selected provider CLI (`codex --version` or `claude --version`) directly, skipping kind configuration, skill preamble, and prompt handling.
- Rejects extra arguments after `version` and validates the provider name the same way the existing session flow does.
- Documents the new syntax and an example in the README script reference for `ai`.

## Why

- There was no quick way to check which Codex or Claude CLI version `ai` is currently wired to launch without dropping the kind/skill machinery entirely and shelling out manually.

## Testing

- `make scripts-lint` - passed
- Manually traced `ai codex version`, `ai claude version`, `ai version` (too few args), and `ai codex version extra` (rejected) through the updated control flow; no automated test harness exists for the root `ai` script beyond shellcheck.
