### PR TITLE
feat(completions): add zsh command suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Commands:
 
 - `afctl ai`: start Codex or Claude with a kind-specific model, reasoning level, and prompt preamble.
 - `afctl clean`: remove dependency vendor directories and rerun `make dep`.
+- `afctl completion zsh`: print the zsh completion script for sourcing from shell startup.
 - `afctl create-ci`: create/configure a CircleCI project and trigger its first pipeline.
 - `afctl deps`: install the managed Homebrew prerequisites and update shared Go developer tools.
-- `afctl help` (also `afctl -h` or `afctl --help`): list the executable commands available in this checkout.
+- `afctl help` (also `afctl -h` or `afctl --help`): list the commands available in this checkout.
 - `afctl load`: run local HTTP/gRPC load tests for specific services.
 - `afctl lsp`: run Ruby LSP after `make dep`.
 - `afctl rotate-ci`: rotate GitHub OAuth CircleCI triggers for slugs in `lib/slugs.sh`.
@@ -101,6 +102,15 @@ Example (`zsh`/`bash`):
 ```bash
 export PATH="/path/to/this/repo:$PATH"
 ```
+
+For zsh completion, add this to `~/.zshrc`:
+
+```zsh
+source <(afctl completion zsh)
+```
+
+The generated script initializes `compinit` itself when needed and discovers the
+available `afctl` commands from executable files in `libexec/`.
 
 > [!TIP]
 > From a shell already inside this repository, `export PATH="$(pwd):$PATH"` is
@@ -437,6 +447,17 @@ To work on an existing entry, start an implement/fix session with that explicit
 skill and ledger ID, such as `afctl ai codex code-issues-implement -s lib ISSUE-1`.
 For a same-prefix batch, use `ISSUE-1/2/3`. The selected skill resolves the
 ledger and owns the batch's sequential validation and stop behavior.
+
+### ⌨️ `afctl completion`
+
+Print a completion script for a supported shell.
+
+```zsh
+source <(afctl completion zsh)
+```
+
+The generated zsh completion discovers the executable `libexec` commands in
+the current `afctl` checkout and completes documented argument values.
 
 ### 🚀 `afctl create-ci`
 

--- a/afctl
+++ b/afctl
@@ -18,9 +18,21 @@ EOF
     [ -x "$subcommand_path" ] || continue
     printf '  %s\n' "${subcommand_path##*/}" >&2
   done
+  printf '  completion\n' >&2
 
   printf '\nSee %s/README.md for command details.\n' "$script_dir" >&2
   exit "${1:-1}"
+}
+
+# Prints the zsh completion script with this checkout's absolute path embedded.
+completion() {
+  if [ "$#" -ne 1 ] || [ "$1" != zsh ]; then
+    echo "usage: afctl completion zsh" >&2
+    return 1
+  fi
+
+  printf 'typeset -g _afctl_completion_dir=%q\n' "$script_dir"
+  cat "$script_dir/completions/afctl.sh"
 }
 
 readonly command="${1:-}"
@@ -28,6 +40,11 @@ readonly command="${1:-}"
 case "$command" in
 '' | help | -h | --help)
   usage 0
+  ;;
+completion)
+  shift
+  completion "$@"
+  exit 0
   ;;
 *[!a-z0-9-]*)
   printf 'unknown command: %s\n' "$command" >&2

--- a/completions/afctl.sh
+++ b/completions/afctl.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env zsh
+
+# afctl completion zsh supplies the checkout path before this script is sourced.
+if ! (( $+functions[compdef] )); then
+  autoload -Uz compinit
+  compinit
+fi
+
+_afctl_skill_kinds() {
+  local skill_dir
+  local -a kinds
+
+  for skill_dir in "$_afctl_completion_dir"/bin/skills/*(/N); do
+    kinds+=("${skill_dir:t}")
+  done
+
+  _describe -t kinds 'skill kind' kinds
+}
+
+_afctl_ai_options() {
+  local -a options
+
+  case ${words[CURRENT - 1]} in
+  -s | --scope)
+    _files -/
+    return
+    ;;
+  -f | --file)
+    _files
+    return
+    ;;
+  esac
+
+  options=(-s --scope -c --confidence -e --effort --reasoning -f --file -a --auto --)
+  compadd -a options
+}
+
+_afctl_ai() {
+  local skill_dir
+  local -a commands kinds
+
+  case $CURRENT in
+  3)
+    commands=(codex claude ledger skills help)
+    compadd -a commands
+    return
+    ;;
+  esac
+
+  case $words[3] in
+  codex | claude)
+    if (( CURRENT == 4 )); then
+      kinds=(version)
+      for skill_dir in "$_afctl_completion_dir"/bin/skills/*(/N); do
+        kinds+=("${skill_dir:t}")
+      done
+      compadd -a kinds
+      return
+    fi
+
+    [[ $words[4] == version ]] || _afctl_ai_options
+    ;;
+  ledger)
+    if (( CURRENT == 4 )); then
+      _afctl_skill_kinds
+      return
+    fi
+
+    case ${words[CURRENT - 1]} in
+    -s | --scope)
+      _files -/
+      ;;
+    *)
+      compadd -- -s --scope
+      ;;
+    esac
+    ;;
+  help)
+    (( CURRENT == 4 )) && _afctl_skill_kinds
+    ;;
+  esac
+}
+
+_afctl_update() {
+  case $CURRENT in
+  3)
+    _values 'directory set' ruby go services all
+    ;;
+  4)
+    _values action latest purge dep clean done ci submodule
+    ;;
+  5)
+    [[ $words[4] == submodule ]] && _values kind build docs feature fix refactor test
+    ;;
+  esac
+}
+
+_afctl_update_buf() {
+  case $CURRENT in
+  3)
+    _values 'directory set' ruby go services all
+    ;;
+  4)
+    _values action new done
+    ;;
+  5)
+    [[ $words[4] == new ]] && _values kind build docs feature fix refactor test
+    ;;
+  esac
+}
+
+_afctl_update_ruby() {
+  case $CURRENT in
+  3)
+    _values 'directory set' ruby services all
+    ;;
+  4)
+    _values action new bundler done
+    ;;
+  5)
+    case $words[4] in
+    new)
+      _values kind build docs feature fix refactor test
+      ;;
+    bundler)
+      _message 'Bundler version'
+      ;;
+    esac
+    ;;
+  esac
+}
+
+_afctl_update_service() {
+  case $CURRENT in
+  3)
+    _values action new done
+    ;;
+  4)
+    [[ $words[3] == new ]] && _values kind build docs feature fix refactor test
+    ;;
+  5)
+    [[ $words[3] == new ]] && _message 'go-service version'
+    ;;
+  esac
+}
+
+_afctl() {
+  local command command_path
+  local -a commands
+
+  if (( CURRENT == 2 )); then
+    commands=(completion help -h --help)
+    for command_path in "$_afctl_completion_dir"/libexec/*(N); do
+      [[ -x $command_path ]] && commands+=("${command_path:t}")
+    done
+
+    _describe -t commands 'afctl command' commands
+    return
+  fi
+
+  command=$words[2]
+  case $command in
+  completion)
+    (( CURRENT == 3 )) && _values shell zsh
+    ;;
+  ai)
+    _afctl_ai
+    ;;
+  load)
+    case $CURRENT in
+    3) _values kind http grpc ;;
+    4) _values service standort bezeichner ;;
+    esac
+    ;;
+  update)
+    _afctl_update
+    ;;
+  update-buf)
+    _afctl_update_buf
+    ;;
+  update-ruby)
+    _afctl_update_ruby
+    ;;
+  update-service)
+    _afctl_update_service
+    ;;
+  update-buf-dep | update-ruby-dep | update-submodule)
+    (( CURRENT == 3 )) && _values kind build docs feature fix refactor test
+    ;;
+  update-bundler | update-root)
+    (( CURRENT == 3 )) && _message version
+    ;;
+  update-service-dep)
+    case $CURRENT in
+    3) _values kind build docs feature fix refactor test ;;
+    4) _message 'go-service version' ;;
+    esac
+    ;;
+  update-docker-dep)
+    _message 'image kind, package, or version'
+    ;;
+  create-ci)
+    (( CURRENT == 3 )) && _message 'repository name'
+    ;;
+  rotate-oauth-ci)
+    case $CURRENT in
+    3) _message 'CircleCI token' ;;
+    4) _message 'project slug' ;;
+    esac
+    ;;
+  esac
+}
+
+compdef _afctl afctl


### PR DESCRIPTION
## What

- Add zsh command suggestions emitted by `afctl`, including available commands and supported argument values.
- Document how to source the generated script from `.zshrc` so maintainers can discover commands interactively.

## Why

- Reduce command-entry friction while keeping the suggestions aligned with the checkout's executable commands.

## Testing

- `make scripts-lint` - passed
- `zsh -n completions/afctl.sh` - passed
- `./afctl help`, `./afctl completion zsh | zsh -n`, and invalid-shell checks - passed
- No established automated completion-test harness exists; CI will run the repository lint and security checks.

AI-assisted-by: [Codex](https://openai.com/codex/)
