### PR TITLE
feat(ai): enable provider automatic approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ afctl ai claude test-gaps-find "focus on the command-line interface"
 afctl ai codex test-gaps-find -s lib "focus on the command-line interface"
 afctl ai codex test-gaps-find -s lib -c 95% "focus on the command-line interface"
 afctl ai codex test-gaps-find -s lib --reasoning high "focus on the command-line interface"
+afctl ai codex code -a "add a cache for this request"
 afctl ai codex code-issues-implement -s lib ISSUE-1
 afctl ai ledger code-issues-implement -s lib
 afctl ai ledger code-issues-implement -s lib ISSUE-12
@@ -419,10 +420,10 @@ Confidence is omitted by default, preserving the shared `>= 90%` minimum, and
 can be overridden with `-c <confidence>` (or `--confidence <confidence>`),
 such as `95%`. The configured reasoning level can be overridden for one run
 with `-e <effort>`, `--effort <effort>`, or `--reasoning <effort>`. Use `-a`
-(or `--auto`) to skip approval prompts for one run: Claude gets
-`--dangerously-skip-permissions`, and Codex gets `--ask-for-approval never`.
-Codex's sandbox stays enabled either way; only its approval prompts are
-skipped. Use `--` before the prompt when it begins with `-s`, `--scope`, `-c`,
+(or `--auto`) to enable the selected provider's automatic approval mode for one
+run. Codex gets `--approve-for-me`, which routes approval requests through
+automatic review with a `workspace-write` sandbox. Claude gets
+`--permission-mode auto`. Use `--` before the prompt when it begins with `-s`, `--scope`, `-c`,
 `--confidence`, `-e`, `--effort`, `--reasoning`, `-f`, `--file`, `-a`, or
 `--auto`. Use `-f <file>` (or `--file <file>`) to read a multiline
 prompt from a readable regular file. The file path is relative to the current

--- a/libexec/ai
+++ b/libexec/ai
@@ -183,7 +183,7 @@ show_skill_help() {
   printf '  -c, --confidence <confidence>   Confidence target\n'
   printf '  -e, --effort, --reasoning <effort>  Override reasoning level\n'
   printf '  -f, --file <file>               Read the prompt from a file\n'
-  printf '  -a, --auto                      Skip provider approval prompts\n'
+  printf '  -a, --auto                      Enable the provider automatic approval mode\n'
   printf '  --                              Treat remaining arguments as prompt text\n'
   printf '\nConstraints:\n'
   printf '  A prompt file cannot be combined with inline prompt text.\n'
@@ -313,13 +313,13 @@ build_command() {
   codex)
     command=(codex --model "$model" -c "model_reasoning_effort=\"$reasoning\"")
     if [ -n "$auto" ]; then
-      command+=(--ask-for-approval never)
+      command+=(--approve-for-me)
     fi
     ;;
   claude)
     command=(claude --model "$model" --effort "$reasoning")
     if [ -n "$auto" ]; then
-      command+=(--dangerously-skip-permissions)
+      command+=(--permission-mode auto)
     fi
     ;;
   esac


### PR DESCRIPTION
## What

- Enables the current automatic approval modes for Codex and Claude when `afctl ai --auto` is used, and documents the resulting workspace-write and automatic-review behavior.
- Keeps the scope to provider launch arguments and user guidance; no repository permissions or defaults change unless `--auto` is supplied.

## Why

- The previous provider arguments either disabled approvals more broadly than intended or no longer matched the current CLI contract, making the documented convenience option unsafe or ineffective.

## Testing

- `make scripts-lint` - passed
- `git diff --check` - passed
- `codex --help` and `claude --help` - passed; confirmed the documented provider flags are accepted by the installed CLIs.
- Runtime provider launch coverage is not available because this repository has no focused harness for `afctl ai` command construction; CI additionally runs `make lint` and `make sec`.

AI-assisted-by: [Codex](https://openai.com/codex/)
